### PR TITLE
Feature/#450 validate currency amounts for transfer requests

### DIFF
--- a/src/interface/swagger.json
+++ b/src/interface/swagger.json
@@ -975,7 +975,8 @@
             "type": "object",
             "properties": {
                 "amount": {
-                    "type": "number"
+                    "type": "number",
+                    "minimum": 0.001
                 },
                 "currency": {
                     "type": "string"


### PR DESCRIPTION
edited the swagger.json to allow only amounts bigger than 0.001