### PR TITLE
changed the hub name to be loaded from default.json

### DIFF
--- a/src/models/settlement/facade.js
+++ b/src/models/settlement/facade.js
@@ -39,7 +39,7 @@ const Utility = require('../../handlers/lib/utility')
 const getNotificationMessage = function (action, destination, payload) {
   return {
     id: Uuid(),
-    from: Config.HUB_PARTICIPANT.NAME,
+    from: Config.HUB_NAME,
     to: destination,
     type: 'application/json',
     content: {

--- a/src/models/settlement/facade.js
+++ b/src/models/settlement/facade.js
@@ -39,7 +39,7 @@ const Utility = require('../../handlers/lib/utility')
 const getNotificationMessage = function (action, destination, payload) {
   return {
     id: Uuid(),
-    from: Enums.headers.FSPIOP.SWITCH,
+    from: Config.HUB_PARTICIPANT.NAME,
     to: destination,
     type: 'application/json',
     content: {


### PR DESCRIPTION
The CEP is sending (yet) requests to receive notification endpoint details from the Admin API and there is no participant called central-switch.