### PR TITLE
Feature/762 optimize dockerfiles

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ defaults_working_directory: &defaults_working_directory
 
 defaults_docker_node: &defaults_docker_node
   docker:
-    - image: mhart/alpine-node:10.15.1
+    - image: node:10.15.3-alpine
 
 defaults_docker_helm_kube: &defaults_docker_helm_kube
   docker:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,20 @@
-FROM mhart/alpine-node:10.15.1
+FROM node:10.15.3-alpine
 
 WORKDIR /opt/central-settlement
-COPY config /opt/central-settlement/config
-COPY src /opt/central-settlement/src
-COPY test /opt/central-settlement/test
-COPY package.json /opt/central-settlement
-COPY README.md /opt/central-settlement
 
 RUN apk add --no-cache -t build-dependencies git make gcc g++ python libtool autoconf automake \
     && cd $(npm root -g)/npm \
     && npm config set unsafe-perm true
 
+COPY package.json package-lock.json* /opt/central-settlement/
 RUN npm install --production && \
   npm uninstall -g npm
 
 RUN apk del build-dependencies
+
+COPY config /opt/central-settlement/config
+COPY src /opt/central-settlement/src
+COPY README.md /opt/central-settlement
 
 EXPOSE 3007
 CMD node src/server.js

--- a/test-integration.Dockerfile
+++ b/test-integration.Dockerfile
@@ -1,25 +1,25 @@
-FROM mhart/alpine-node:10.15.1
+FROM node:10.15.3-alpine
 USER root
 
 WORKDIR /opt/central-settlement
+
+RUN apk add --no-cache -t build-dependencies git make gcc g++ python libtool autoconf automake \
+    && cd $(npm root -g)/npm \
+    && npm config set unsafe-perm true \
+    && npm install -g tape tap-xunit
+
+COPY package.json package-lock.json* /opt/central-settlement/
+RUN npm install
+
+RUN apk del build-dependencies
+
 COPY config /opt/central-settlement/config
 COPY src /opt/central-settlement/src
 COPY test /opt/central-settlement/test
-COPY package.json /opt/central-settlement
 COPY README.md /opt/central-settlement
 
 # overwrite default.json with integration environment specific config
 RUN cp -f /opt/central-settlement/test/integration-config-centralsettlement.json /opt/central-settlement/config/default.json
-
-RUN apk add --no-cache -t build-dependencies git make gcc g++ python libtool autoconf automake \
-    && cd $(npm root -g)/npm \
-    && npm config set unsafe-perm true
-
-RUN npm install
-
-RUN npm install -g tape tap-xunit
-
-RUN apk del build-dependencies
 
 EXPOSE 3007
 CMD node src/server.js

--- a/test/integration-runner.sh
+++ b/test/integration-runner.sh
@@ -234,7 +234,7 @@ is_ml_api_adapter_up() {
 # Script execution
 
 >&1 echo "Building Docker Image $DOCKER_IMAGE:$DOCKER_TAG with $DOCKER_FILE"
-docker build --no-cache -t $DOCKER_IMAGE:$DOCKER_TAG -f $DOCKER_FILE .
+docker build --cache-from $DOCKER_IMAGE:$DOCKER_TAG -t $DOCKER_IMAGE:$DOCKER_TAG -f $DOCKER_FILE .
 
 if [ "$?" != 0 ]
 then


### PR DESCRIPTION
Part of https://github.com/mojaloop/project/issues/762

- Reordered and optimized the commands for `Dockerfile` and `test-integration.Dockerfile` to take better advantage of docker layer caching.
- Changed base image to official alpine image to `node:10.15.3-alpine`

All of these images build and test locally just fine.