### PR TITLE
feature/801-update-ci-license-and-audit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,8 +339,6 @@ jobs:
       - run:
           name: Install general dependencies
           command: *defaults_Dependencies
-      - run:
-          <<: *defaults_environment
       - restore_cache:
           keys:
             - dependency-cache-{{ checksum "package.json" }}
@@ -363,8 +361,6 @@ jobs:
       - run:
           name: Install general dependencies
           command: *defaults_Dependencies
-      - run:
-          <<: *defaults_environment
       - run:
           <<: *defaults_license_scanner
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ defaults_Dependencies: &defaults_Dependencies |
     apk --no-cache add ca-certificates
     apk --no-cache add curl
     apk --no-cache add openssh-client
+    apk --no-cache add bash
     apk add --no-cache -t build-dependencies make gcc g++ python libtool autoconf automake
     npm config set unsafe-perm true
     npm install -g node-gyp
@@ -30,6 +31,12 @@ defaults_awsCliDependencies: &defaults_awsCliDependencies |
             mailcap
     pip install --upgrade awscli==1.14.5 s3cmd==2.0.1 python-magic
     apk -v --purge del py-pip
+
+defaults_license_scanner: &defaults_license_scanner
+  name: Install and set up license-scanner
+  command: |
+    git clone https://github.com/mojaloop/license-scanner /tmp/license-scanner
+    cd /tmp/license-scanner && make build default-files set-up
 
 defaults_build_docker_login: &defaults_build_docker_login
   name: Login to Docker Hub
@@ -324,6 +331,49 @@ jobs:
 #       - store_test_results:
 #           path: ./test/results
 
+  vulnerability-check:
+    <<: *defaults_working_directory
+    <<: *defaults_docker_node
+    steps:
+      - checkout
+      - run:
+          name: Install general dependencies
+          command: *defaults_Dependencies
+      - run:
+          <<: *defaults_environment
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+      - run:
+          name: Create dir for test results
+          command: mkdir -p ./audit/results
+      - run:
+          name: Check for new npm vulnerabilities
+          command: npm run audit:check -- --json > ./audit/results/auditResults.json 
+      - store_artifacts:
+          path: ./audit/results
+          prefix: audit
+          
+  audit-licenses:
+    <<: *defaults_working_directory
+    <<: *defaults_docker_node
+    steps:
+      - checkout
+      - run:
+          name: Install general dependencies
+          command: *defaults_Dependencies
+      - run:
+          <<: *defaults_environment
+      - run:
+          <<: *defaults_license_scanner
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+      - run:
+          name: Run the license-scanner
+          command: cd /tmp/license-scanner && pathToRepo=$CIRCLE_WORKING_DIRECTORY make run
+      - store_artifacts:
+          path: /tmp/license-scanner/results
+          prefix: licenses
+
   build-snapshot:
     machine: true
     <<: *defaults_working_directory
@@ -355,6 +405,14 @@ jobs:
           <<: *defaults_build_docker_login
       - run:
           <<: *defaults_build_docker_build
+      - run:
+          <<: *defaults_license_scanner
+      - run:
+          name: Run the license-scanner
+          command: cd /tmp/license-scanner && mode=docker dockerImage=$DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG make run
+      - store_artifacts:
+          path: /tmp/license-scanner/results
+          prefix: licenses
       - run:
           <<: *defaults_build_docker_publish
       - run:
@@ -496,6 +554,28 @@ workflows:
 #               ignore:
 #                 - /feature*/
 #                 - /bugfix*/
+      - vulnerability-check:
+          context: org-global
+          requires:
+            - setup
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore:
+                - /feature*/
+                - /bugfix*/
+      - audit-licenses:
+          context: org-global
+          requires:
+            - setup
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore:
+                - /feature*/
+                - /bugfix*/
       - build-snapshot:
           context: org-global
           requires:
@@ -530,6 +610,8 @@ workflows:
             - test-integration
             # - test-functional
             # - test-spec
+            - vulnerability-check
+            - audit-licenses
           filters:
             tags:
               only: /v[0-9]+(\.[0-9]+)*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -342,7 +342,9 @@ jobs:
       - run:
           <<: *defaults_environment
       - restore_cache:
-          key: dependency-cache-{{ checksum "package.json" }}
+          keys:
+            - dependency-cache-{{ checksum "package.json" }}
+            - dependency-cache-
       - run:
           name: Create dir for test results
           command: mkdir -p ./audit/results
@@ -366,7 +368,9 @@ jobs:
       - run:
           <<: *defaults_license_scanner
       - restore_cache:
-          key: dependency-cache-{{ checksum "package.json" }}
+          keys:
+            - dependency-cache-{{ checksum "package.json" }}
+            - dependency-cache-
       - run:
           name: Run the license-scanner
           command: cd /tmp/license-scanner && pathToRepo=$CIRCLE_WORKING_DIRECTORY make run

--- a/README.md
+++ b/README.md
@@ -73,3 +73,19 @@ npm run migrate
 docker exec -it cs_central-settlement sh
 npm run test:int
 ```
+
+## Auditing Dependencies
+
+We use `npm-audit-resolver` along with `npm audit` to check dependencies for vulnerabilities, and keep track of resolved dependencies with an `audit-resolv.json` file.
+
+To start a new resolution process, run:
+```bash
+npm run audit:resolve
+```
+
+You can then check to see if the CI will pass based on the current dependencies with:
+```bash
+npm run audit:check
+```
+
+And commit the changed `audit-resolv.json` to ensure that CircleCI will build correctly.

--- a/audit-resolv.json
+++ b/audit-resolv.json
@@ -1,0 +1,14 @@
+{
+  "1065|@mojaloop/central-ledger>@mojaloop/central-services-database>lodash": {
+    "ignore": 1
+  },
+  "1065|@mojaloop/central-ledger>lodash": {
+    "ignore": 1
+  },
+  "1065|@mojaloop/central-services-database>lodash": {
+    "ignore": 1
+  },
+  "812|@mojaloop/central-ledger>jsdoc>marked": {
+    "ignore": 1
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,26 +1,22 @@
 {
     "name": "central-settlement",
-<<<<<<< HEAD
-    "version": "7.1.1",
-=======
-    "version": "7.1.0",
->>>>>>> b19a35636787e12a664d79f8419d3081b514cfc0
+    "version": "7.1.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
         "@babel/code-frame": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-            "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+            "version": "7.5.5",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+            "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
             "dev": true,
             "requires": {
                 "@babel/highlight": "^7.0.0"
             }
         },
         "@babel/highlight": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-            "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+            "version": "7.5.0",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
+            "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
             "dev": true,
             "requires": {
                 "chalk": "^2.0.0",
@@ -409,7 +405,6 @@
                 "@now-ims/hapi-now-auth": "1.3.1",
                 "base64url": "3.0.1",
                 "blipp": "3.1.2",
-                "bluebird": "3.5.3",
                 "boom": "7.3.0",
                 "catbox-memory": "4.0.1",
                 "commander": "2.19.0",
@@ -467,7 +462,6 @@
                     "requires": {
                         "@mojaloop/central-services-shared": "5.2.0",
                         "async": "2.6.2",
-                        "bluebird": "3.5.3",
                         "debug": "4.1.1",
                         "events": "3.0.0",
                         "node-rdkafka": "2.5.1"
@@ -515,7 +509,6 @@
             "resolved": "https://registry.npmjs.org/@mojaloop/central-services-database/-/central-services-database-5.2.1.tgz",
             "integrity": "sha512-hvqNZ63ylgYTKUBHzOeaQoRwGafMqToIq1/HZXPJ0WtqAsVg59yJs9DG3fvg66v4P+6Ub16wwrW17HDHjpgPqQ==",
             "requires": {
-                "bluebird": "3.5.3",
                 "knex": "0.16.3",
                 "lodash": "4.17.11",
                 "mysql": "2.16.0",
@@ -530,13 +523,12 @@
             }
         },
         "@mojaloop/central-services-error-handling": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/@mojaloop/central-services-error-handling/-/central-services-error-handling-7.1.1.tgz",
-            "integrity": "sha512-YO59QiWy1miO47urzPuqYmYpDGeO1veJeoyiYPjCMUFODEP5sZINzE6fOhXUQl8y8iCgus92j/cighf9uzmmbQ==",
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/@mojaloop/central-services-error-handling/-/central-services-error-handling-7.1.2.tgz",
+            "integrity": "sha512-8bNKzNvZDG0ZFFgBPrWPXuUGTCbgBhtP1gjCatM8Vik3Wd5sK+8Zac1JLE1mK8x85gy7U8I4cIT74XEV7D5t9A==",
             "requires": {
                 "@modusbox/mojaloop-sdk-standard-components": "0.0.36",
                 "@mojaloop/central-services-shared": "6.4.1"
-<<<<<<< HEAD
             }
         },
         "@mojaloop/central-services-health": {
@@ -570,8 +562,6 @@
                         }
                     }
                 }
-=======
->>>>>>> b19a35636787e12a664d79f8419d3081b514cfc0
             }
         },
         "@mojaloop/central-services-metrics": {
@@ -620,7 +610,6 @@
                 "@mojaloop/central-services-shared": "5.2.0",
                 "async": "2.6.2",
                 "base64url": "3.0.1",
-                "bluebird": "3.5.3",
                 "clone": "2.1.2",
                 "data-urls": "^1.1.0",
                 "debug": "4.1.1",
@@ -660,8 +649,7 @@
             "resolved": "https://registry.npmjs.org/@mojaloop/forensic-logging-client/-/forensic-logging-client-5.2.0.tgz",
             "integrity": "sha512-WzhOIysAw+mfBRsczH9OTF0OzZMYLaxEo+g/A3uzt1kk82bkzJy13v7KFvljmgqe3jVwA6f2RdGllxUad3px/w==",
             "requires": {
-                "@mojaloop/central-services-shared": "5.2.0",
-                "bluebird": "3.5.3"
+                "@mojaloop/central-services-shared": "5.2.0"
             },
             "dependencies": {
                 "@mojaloop/central-services-shared": {
@@ -694,27 +682,28 @@
             }
         },
         "@sinonjs/commons": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.0.tgz",
-            "integrity": "sha512-j4ZwhaHmwsCb4DlDOIWnI5YyKDNMoNThsmwEpfHx6a1EpsGZ9qYLxP++LMlmBRjtGptGHFsGItJ768snllFWpA==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.4.0.tgz",
+            "integrity": "sha512-9jHK3YF/8HtJ9wCAbG+j8cD0i0+ATS9A7gXFqS36TblLPNy6rEEc+SB0imo91eCboGaBYGV/MT1/br/J+EE7Tw==",
             "dev": true,
             "requires": {
                 "type-detect": "4.0.8"
             }
         },
         "@sinonjs/formatio": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.1.0.tgz",
-            "integrity": "sha512-ZAR2bPHOl4Xg6eklUGpsdiIJ4+J1SNag1DHHrG/73Uz/nVwXqjgUtRPLoS+aVyieN9cSbc0E4LsU984tWcDyNg==",
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.1.tgz",
+            "integrity": "sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==",
             "dev": true,
             "requires": {
-                "@sinonjs/samsam": "^2 || ^3"
+                "@sinonjs/commons": "^1",
+                "@sinonjs/samsam": "^3.1.0"
             }
         },
         "@sinonjs/samsam": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.2.0.tgz",
-            "integrity": "sha512-j5F1rScewLtx6pbTK0UAjA3jJj4RYiSKOix53YWv+Jzy/AZ69qHxUpU8fwVLjyKbEEud9QrLpv6Ggs7WqTimYw==",
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.2.tgz",
+            "integrity": "sha512-ILO/rR8LfAb60Y1Yfp9vxfYAASK43NFC2mLzpvLUbCQY/Qu8YwReboseu8aheCEkyElZF2L2T9mHcR2bgdvZyA==",
             "dev": true,
             "requires": {
                 "@sinonjs/commons": "^1.0.2",
@@ -745,9 +734,9 @@
             "dev": true
         },
         "acorn": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.0.tgz",
-            "integrity": "sha512-MW/FjM+IvU9CgBzjO3UIPCE2pyEwUsoFl+VGdczOPEdxfGFjuKny/gN54mOuX7Qxmb9Rg9MCn2oKiSUeW+pjrw==",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.0.tgz",
+            "integrity": "sha512-8oe72N3WPMjA+2zVG71Ia0nXZ8DpQH+QyyHO+p06jT8eg8FGG3FbcUIi8KziHlAfheJQZeoqbvq1mQSQHXKYLw==",
             "dev": true
         },
         "acorn-jsx": {
@@ -757,9 +746,9 @@
             "dev": true
         },
         "ajv": {
-            "version": "6.9.2",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.2.tgz",
-            "integrity": "sha512-4UFy0/LgDo7Oa/+wOAlj44tp9K78u38E5/359eSrqEp1Z5PdVfimCcs7SluXMP755RUQu6d2b4AvF0R1C9RZjg==",
+            "version": "6.10.2",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+            "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
             "requires": {
                 "fast-deep-equal": "^2.0.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -1263,9 +1252,9 @@
             }
         },
         "bluebird": {
-            "version": "3.5.3",
-            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
-            "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
+            "version": "3.5.5",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+            "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w=="
         },
         "bn.js": {
             "version": "4.11.8",
@@ -1395,12 +1384,11 @@
             }
         },
         "callsites": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.0.0.tgz",
-            "integrity": "sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
             "dev": true
         },
-<<<<<<< HEAD
         "camelcase": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
@@ -1413,8 +1401,6 @@
             "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
             "dev": true
         },
-=======
->>>>>>> b19a35636787e12a664d79f8419d3081b514cfc0
         "caseless": {
             "version": "0.12.0",
             "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -1741,15 +1727,12 @@
                 "which": "^1.2.9"
             }
         },
-<<<<<<< HEAD
         "crypto-random-string": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
             "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
             "dev": true
         },
-=======
->>>>>>> b19a35636787e12a664d79f8419d3081b514cfc0
         "dashdash": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -1818,6 +1801,12 @@
                 "strip-bom": "^2.0.0"
             }
         },
+        "default-shell": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/default-shell/-/default-shell-1.0.1.tgz",
+            "integrity": "sha1-dSMEvdxhdPSespy5iP7qC4gTyLw=",
+            "dev": true
+        },
         "defaults": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
@@ -1837,9 +1826,9 @@
             },
             "dependencies": {
                 "object-keys": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.0.tgz",
-                    "integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg==",
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+                    "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
                     "dev": true
                 }
             }
@@ -1888,23 +1877,23 @@
             "dev": true
         },
         "deglob": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/deglob/-/deglob-2.1.1.tgz",
-            "integrity": "sha512-2kjwuGGonL7gWE1XU4Fv79+vVzpoQCl0V+boMwWtOQJV2AGDabCwez++nB1Nli/8BabAfZQ/UuHPlp6AymKdWw==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/deglob/-/deglob-3.1.0.tgz",
+            "integrity": "sha512-al10l5QAYaM/PeuXkAr1Y9AQz0LCtWsnJG23pIgh44hDxHFOj36l6qvhfjnIWBYwZOqM1fXUFV9tkjL7JPdGvw==",
             "dev": true,
             "requires": {
                 "find-root": "^1.0.0",
                 "glob": "^7.0.5",
-                "ignore": "^3.0.9",
+                "ignore": "^5.0.0",
                 "pkg-config": "^1.1.0",
                 "run-parallel": "^1.1.2",
                 "uniq": "^1.0.1"
             },
             "dependencies": {
                 "ignore": {
-                    "version": "3.3.10",
-                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-                    "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.2.tgz",
+                    "integrity": "sha512-vdqWBp7MyzdmHkkRWV5nY+PfGRbYbahfuvsBCh277tq+w9zyNi7h5CYJCK0kmzti9kU+O/cB7sE8HvKv6aXAKQ==",
                     "dev": true
                 }
             }
@@ -2134,9 +2123,9 @@
             },
             "dependencies": {
                 "object-keys": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.0.tgz",
-                    "integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg==",
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+                    "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
                     "dev": true
                 }
             }
@@ -2164,32 +2153,33 @@
             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
         "eslint": {
-            "version": "5.14.1",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.14.1.tgz",
-            "integrity": "sha512-CyUMbmsjxedx8B0mr79mNOqetvkbij/zrXnFeK2zc3pGRn3/tibjiNAv/3UxFEyfMDjh+ZqTrJrEGBFiGfD5Og==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.0.1.tgz",
+            "integrity": "sha512-DyQRaMmORQ+JsWShYsSg4OPTjY56u1nCjAmICrE8vLWqyLKxhFXOthwMj1SA8xwfrv0CofLNVnqbfyhwCkaO0w==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.0.0",
-                "ajv": "^6.9.1",
+                "ajv": "^6.10.0",
                 "chalk": "^2.1.0",
                 "cross-spawn": "^6.0.5",
                 "debug": "^4.0.1",
                 "doctrine": "^3.0.0",
-                "eslint-scope": "^4.0.0",
+                "eslint-scope": "^4.0.3",
                 "eslint-utils": "^1.3.1",
                 "eslint-visitor-keys": "^1.0.0",
-                "espree": "^5.0.1",
+                "espree": "^6.0.0",
                 "esquery": "^1.0.1",
                 "esutils": "^2.0.2",
                 "file-entry-cache": "^5.0.1",
                 "functional-red-black-tree": "^1.0.1",
-                "glob": "^7.1.2",
+                "glob-parent": "^3.1.0",
                 "globals": "^11.7.0",
                 "ignore": "^4.0.6",
                 "import-fresh": "^3.0.0",
                 "imurmurhash": "^0.1.4",
                 "inquirer": "^6.2.2",
-                "js-yaml": "^3.12.0",
+                "is-glob": "^4.0.0",
+                "js-yaml": "^3.13.1",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
                 "levn": "^0.3.0",
                 "lodash": "^4.17.11",
@@ -2197,7 +2187,6 @@
                 "mkdirp": "^0.5.1",
                 "natural-compare": "^1.4.0",
                 "optionator": "^0.8.2",
-                "path-is-inside": "^1.0.2",
                 "progress": "^2.0.0",
                 "regexpp": "^2.0.1",
                 "semver": "^5.5.1",
@@ -2205,18 +2194,29 @@
                 "strip-json-comments": "^2.0.1",
                 "table": "^5.2.3",
                 "text-table": "^0.2.0"
+            },
+            "dependencies": {
+                "is-glob": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+                    "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "^2.1.1"
+                    }
+                }
             }
         },
         "eslint-config-standard": {
-            "version": "12.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-12.0.0.tgz",
-            "integrity": "sha512-COUz8FnXhqFitYj4DTqHzidjIL/t4mumGZto5c7DrBpvWoie+Sn3P4sLEzUGeYhRElWuFEf8K1S1EfvD1vixCQ==",
+            "version": "13.0.1",
+            "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-13.0.1.tgz",
+            "integrity": "sha512-zLKp4QOgq6JFgRm1dDCVv1Iu0P5uZ4v5Wa4DTOkg2RFMxdCX/9Qf7lz9ezRj2dBRa955cWQF/O/LWEiYWAHbTw==",
             "dev": true
         },
         "eslint-config-standard-jsx": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-6.0.2.tgz",
-            "integrity": "sha512-D+YWAoXw+2GIdbMBRAzWwr1ZtvnSf4n4yL0gKGg7ShUOGXkSOLerI17K4F6LdQMJPNMoWYqepzQD/fKY+tXNSg==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-7.0.0.tgz",
+            "integrity": "sha512-OiKOF3MFVmWOCVfsi8GHlVorOEiBsPzAnUhM3c6HML94O2krbdQ/eMABySHgHHOIBYRls9sR9I3lo6O0vXhVEg==",
             "dev": true
         },
         "eslint-import-resolver-node": {
@@ -2247,9 +2247,9 @@
             }
         },
         "eslint-module-utils": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.3.0.tgz",
-            "integrity": "sha512-lmDJgeOOjk8hObTysjqH7wyMi+nsHwwvfBykwfhjR1LNdd7C2uFJBvx4OpWYpXOw4df1yE1cDEVd1yLHitk34w==",
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.4.0.tgz",
+            "integrity": "sha512-14tltLm38Eu3zS+mt0KvILC3q8jyIAH518MlG+HO0p+yK885Lb1UHTY/UgR91eOyGdmxAPb+OLoW4znqIT6Ndw==",
             "dev": true,
             "requires": {
                 "debug": "^2.6.8",
@@ -2284,21 +2284,22 @@
             }
         },
         "eslint-plugin-import": {
-            "version": "2.14.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.14.0.tgz",
-            "integrity": "sha512-FpuRtniD/AY6sXByma2Wr0TXvXJ4nA/2/04VPlfpmUDPOpOY264x+ILiwnrk/k4RINgDAyFZByxqPUbSQ5YE7g==",
+            "version": "2.18.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.18.1.tgz",
+            "integrity": "sha512-YEESFKOcMIXJTosb5YaepqVhQHGMb8dxkgov560GqMDP/658U5vk6FeVSR7xXLeYkPc7xPYy+uAoiYE/bKMphA==",
             "dev": true,
             "requires": {
+                "array-includes": "^3.0.3",
                 "contains-path": "^0.1.0",
-                "debug": "^2.6.8",
+                "debug": "^2.6.9",
                 "doctrine": "1.5.0",
-                "eslint-import-resolver-node": "^0.3.1",
-                "eslint-module-utils": "^2.2.0",
-                "has": "^1.0.1",
-                "lodash": "^4.17.4",
-                "minimatch": "^3.0.3",
+                "eslint-import-resolver-node": "^0.3.2",
+                "eslint-module-utils": "^2.4.0",
+                "has": "^1.0.3",
+                "minimatch": "^3.0.4",
+                "object.values": "^1.1.0",
                 "read-pkg-up": "^2.0.0",
-                "resolve": "^1.6.0"
+                "resolve": "^1.11.0"
             },
             "dependencies": {
                 "debug": {
@@ -2325,40 +2326,76 @@
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
                     "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
                     "dev": true
+                },
+                "resolve": {
+                    "version": "1.11.1",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
+                    "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+                    "dev": true,
+                    "requires": {
+                        "path-parse": "^1.0.6"
+                    }
                 }
             }
         },
         "eslint-plugin-node": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-7.0.1.tgz",
-            "integrity": "sha512-lfVw3TEqThwq0j2Ba/Ckn2ABdwmL5dkOgAux1rvOk6CO7A6yGyPI2+zIxN6FyNkp1X1X/BSvKOceD6mBWSj4Yw==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-9.1.0.tgz",
+            "integrity": "sha512-ZwQYGm6EoV2cfLpE1wxJWsfnKUIXfM/KM09/TlorkukgCAwmkgajEJnPCmyzoFPQQkmvo5DrW/nyKutNIw36Mw==",
             "dev": true,
             "requires": {
-                "eslint-plugin-es": "^1.3.1",
+                "eslint-plugin-es": "^1.4.0",
                 "eslint-utils": "^1.3.1",
-                "ignore": "^4.0.2",
+                "ignore": "^5.1.1",
                 "minimatch": "^3.0.4",
-                "resolve": "^1.8.1",
-                "semver": "^5.5.0"
+                "resolve": "^1.10.1",
+                "semver": "^6.1.0"
+            },
+            "dependencies": {
+                "ignore": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.2.tgz",
+                    "integrity": "sha512-vdqWBp7MyzdmHkkRWV5nY+PfGRbYbahfuvsBCh277tq+w9zyNi7h5CYJCK0kmzti9kU+O/cB7sE8HvKv6aXAKQ==",
+                    "dev": true
+                },
+                "resolve": {
+                    "version": "1.11.1",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
+                    "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+                    "dev": true,
+                    "requires": {
+                        "path-parse": "^1.0.6"
+                    }
+                },
+                "semver": {
+                    "version": "6.2.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz",
+                    "integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A==",
+                    "dev": true
+                }
             }
         },
         "eslint-plugin-promise": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.0.1.tgz",
-            "integrity": "sha512-Si16O0+Hqz1gDHsys6RtFRrW7cCTB6P7p3OJmKp3Y3dxpQE2qwOA7d3xnV+0mBmrPoi0RBnxlCKvqu70te6wjg==",
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz",
+            "integrity": "sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==",
             "dev": true
         },
         "eslint-plugin-react": {
-            "version": "7.11.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.11.1.tgz",
-            "integrity": "sha512-cVVyMadRyW7qsIUh3FHp3u6QHNhOgVrLQYdQEB1bPWBsgbNCHdFAeNMquBMCcZJu59eNthX053L70l7gRt4SCw==",
+            "version": "7.14.2",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.14.2.tgz",
+            "integrity": "sha512-jZdnKe3ip7FQOdjxks9XPN0pjUKZYq48OggNMd16Sk+8VXx6JOvXmlElxROCgp7tiUsTsze3jd78s/9AFJP2mA==",
             "dev": true,
             "requires": {
                 "array-includes": "^3.0.3",
                 "doctrine": "^2.1.0",
                 "has": "^1.0.3",
-                "jsx-ast-utils": "^2.0.1",
-                "prop-types": "^15.6.2"
+                "jsx-ast-utils": "^2.1.0",
+                "object.entries": "^1.1.0",
+                "object.fromentries": "^2.0.0",
+                "object.values": "^1.1.0",
+                "prop-types": "^15.7.2",
+                "resolve": "^1.10.1"
             },
             "dependencies": {
                 "doctrine": {
@@ -2368,6 +2405,15 @@
                     "dev": true,
                     "requires": {
                         "esutils": "^2.0.2"
+                    }
+                },
+                "resolve": {
+                    "version": "1.11.1",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
+                    "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+                    "dev": true,
+                    "requires": {
+                        "path-parse": "^1.0.6"
                     }
                 }
             }
@@ -2379,9 +2425,9 @@
             "dev": true
         },
         "eslint-scope": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
-            "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+            "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
             "dev": true,
             "requires": {
                 "esrecurse": "^4.1.0",
@@ -2389,10 +2435,13 @@
             }
         },
         "eslint-utils": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
-            "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
-            "dev": true
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.0.tgz",
+            "integrity": "sha512-7ehnzPaP5IIEh1r1tkjuIrxqhNkzUJa9z3R92tLJdZIVdWaczEhr3EbhGtsMrVxi1KeR8qA7Off6SWc5WNQqyQ==",
+            "dev": true,
+            "requires": {
+                "eslint-visitor-keys": "^1.0.0"
+            }
         },
         "eslint-visitor-keys": {
             "version": "1.0.0",
@@ -2401,9 +2450,9 @@
             "dev": true
         },
         "espree": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
-            "integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-6.0.0.tgz",
+            "integrity": "sha512-lJvCS6YbCn3ImT3yKkPe0+tJ+mH6ljhGNjHQH9mRtiO6gjhVAOhVXW1yjnwqGwTkK3bGbye+hb00nFNmu0l/1Q==",
             "dev": true,
             "requires": {
                 "acorn": "^6.0.7",
@@ -2568,9 +2617,9 @@
             "integrity": "sha512-kXU1FiTsGT8PyMKtFM074RK/VBpzwuQJicAHqBpsPDeTXBQiSALPjkjKXlyKdG/GP6lR7bBaEkq8qdoO2geu9g=="
         },
         "external-editor": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
-            "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+            "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
             "dev": true,
             "requires": {
                 "chardet": "^0.7.0",
@@ -2834,9 +2883,9 @@
             }
         },
         "flatted": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.0.tgz",
-            "integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
+            "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
             "dev": true
         },
         "for-each": {
@@ -3423,134 +3472,6 @@
                 }
             }
         },
-<<<<<<< HEAD
-=======
-        "find-root": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
-            "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
-            "dev": true
-        },
-        "find-up": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-            "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-            "dev": true,
-            "requires": {
-                "locate-path": "^2.0.0"
-            }
-        },
-        "findup-sync": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
-            "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
-            "requires": {
-                "detect-file": "^1.0.0",
-                "is-glob": "^3.1.0",
-                "micromatch": "^3.0.4",
-                "resolve-dir": "^1.0.1"
-            }
-        },
-        "fined": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/fined/-/fined-1.1.1.tgz",
-            "integrity": "sha512-jQp949ZmEbiYHk3gkbdtpJ0G1+kgtLQBNdP5edFP7Fh+WAYceLQz6yO1SBj72Xkg8GVyTB3bBzAYrHJVh5Xd5g==",
-            "requires": {
-                "expand-tilde": "^2.0.2",
-                "is-plain-object": "^2.0.3",
-                "object.defaults": "^1.1.0",
-                "object.pick": "^1.2.0",
-                "parse-filepath": "^1.0.1"
-            }
-        },
-        "five-bells-condition": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/five-bells-condition/-/five-bells-condition-5.0.1.tgz",
-            "integrity": "sha1-dxAp9Lmlaz2a2P4ej3VJxnXYLYA=",
-            "requires": {
-                "asn1.js": "^4.9.0",
-                "ed25519": "0.0.4",
-                "tweetnacl": "^0.14.1"
-            }
-        },
-        "flagged-respawn": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
-            "integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q=="
-        },
-        "flat-cache": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
-            "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
-            "dev": true,
-            "requires": {
-                "flatted": "^2.0.0",
-                "rimraf": "2.6.3",
-                "write": "1.0.3"
-            }
-        },
-        "flatted": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.0.tgz",
-            "integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==",
-            "dev": true
-        },
-        "for-each": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-            "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-            "dev": true,
-            "requires": {
-                "is-callable": "^1.1.3"
-            }
-        },
-        "for-in": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
-        },
-        "for-own": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
-            "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
-            "requires": {
-                "for-in": "^1.0.1"
-            }
-        },
-        "forever-agent": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-        },
-        "form-data": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-            "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-            "requires": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.6",
-                "mime-types": "^2.1.12"
-            }
-        },
-        "format-util": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/format-util/-/format-util-1.0.3.tgz",
-            "integrity": "sha1-Ay3KShFiYqEsQ/TD7IVmQWxbLZU="
-        },
-        "fragment-cache": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
-            "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
-            "requires": {
-                "map-cache": "^0.2.2"
-            }
-        },
-        "fs.realpath": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-        },
->>>>>>> b19a35636787e12a664d79f8419d3081b514cfc0
         "function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -3564,9 +3485,9 @@
             "dev": true
         },
         "get-stdin": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-            "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
+            "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
             "dev": true
         },
         "get-stream": {
@@ -4586,15 +4507,12 @@
             "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
             "dev": true
         },
-<<<<<<< HEAD
         "ignore-by-default": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
             "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
             "dev": true
         },
-=======
->>>>>>> b19a35636787e12a664d79f8419d3081b514cfc0
         "ilp-packet": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/ilp-packet/-/ilp-packet-2.2.0.tgz",
@@ -4614,9 +4532,9 @@
             }
         },
         "import-fresh": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.0.0.tgz",
-            "integrity": "sha512-pOnA9tfM3Uwics+SaBLCNyZZZbK+4PTu0OPZtLlMIrv17EdBoC15S9Kn8ckJ9TZTyKb3ywNE5y1yeDxxGA7nTQ==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.1.0.tgz",
+            "integrity": "sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==",
             "dev": true,
             "requires": {
                 "parent-module": "^1.0.0",
@@ -4680,9 +4598,9 @@
             "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
         },
         "inquirer": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.2.tgz",
-            "integrity": "sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==",
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.0.tgz",
+            "integrity": "sha512-scfHejeG/lVZSpvCXpsB4j/wQNPM5JC8kiElOI0OUTwmc1RTpXr4H32/HOlQHcZiYl2z2VElwuCVDRG8vFmbnA==",
             "dev": true,
             "requires": {
                 "ansi-escapes": "^3.2.0",
@@ -4691,19 +4609,19 @@
                 "cli-width": "^2.0.0",
                 "external-editor": "^3.0.3",
                 "figures": "^2.0.0",
-                "lodash": "^4.17.11",
+                "lodash": "^4.17.12",
                 "mute-stream": "0.0.7",
                 "run-async": "^2.2.0",
                 "rxjs": "^6.4.0",
                 "string-width": "^2.1.0",
-                "strip-ansi": "^5.0.0",
+                "strip-ansi": "^5.1.0",
                 "through": "^2.3.6"
             },
             "dependencies": {
                 "ansi-regex": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
-                    "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
                     "dev": true
                 },
                 "chalk": {
@@ -4718,12 +4636,12 @@
                     }
                 },
                 "strip-ansi": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
-                    "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^4.0.0"
+                        "ansi-regex": "^4.1.0"
                     }
                 }
             }
@@ -4930,6 +4848,12 @@
             "requires": {
                 "path-is-inside": "^1.0.1"
             }
+        },
+        "is-plain-obj": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+            "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+            "dev": true
         },
         "is-plain-object": {
             "version": "2.0.4",
@@ -5353,12 +5277,13 @@
             }
         },
         "jsx-ast-utils": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
-            "integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.2.1.tgz",
+            "integrity": "sha512-v3FxCcAf20DayI+uxnCuw795+oOIkVu6EnJ1+kSzhqqTZHNkTZ7B66ZgLp4oLJ/gbA64cI0B7WRoHZMSRdyVRQ==",
             "dev": true,
             "requires": {
-                "array-includes": "^3.0.3"
+                "array-includes": "^3.0.3",
+                "object.assign": "^4.1.0"
             }
         },
         "just-extend": {
@@ -5573,9 +5498,9 @@
             }
         },
         "lolex": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/lolex/-/lolex-3.1.0.tgz",
-            "integrity": "sha512-zFo5MgCJ0rZ7gQg69S4pqBsLURbFw11X68C18OcJjJQbqaXm2NoTrGl1IMM3TIz0/BnN1tIs2tzmmqvCsOMMjw==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.1.0.tgz",
+            "integrity": "sha512-BYxIEXiVq5lGIXeVHnsFzqa1TxN5acnKnPCdlZSpzm8viNEOhiigupA4vTQ9HEFQ6nLTQ9wQOgBknJgzUYQ9Aw==",
             "dev": true
         },
         "long": {
@@ -5660,6 +5585,15 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-object-files/-/merge-object-files-2.0.0.tgz",
             "integrity": "sha512-3PqpQPQ9x8ONbUB30TnQw6+giAynlr7zPuGX0RCTHp/oxG0R0A6+WIFH7soFLoZnIKomA7thQrZ+oYFRNzzTww=="
+        },
+        "merge-options": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-1.0.1.tgz",
+            "integrity": "sha512-iuPV41VWKWBIOpBsjoxjDZw8/GbSfZ2mk7N1453bwMrfzdrIk7EzBd+8UVR6rkw67th7xnk9Dytl3J+lHPdxvg==",
+            "dev": true,
+            "requires": {
+                "is-plain-obj": "^1.1"
+            }
         },
         "micromatch": {
             "version": "3.1.10",
@@ -5863,30 +5797,22 @@
             "dev": true
         },
         "nise": {
-            "version": "1.4.10",
-            "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.10.tgz",
-            "integrity": "sha512-sa0RRbj53dovjc7wombHmVli9ZihXbXCQ2uH3TNm03DyvOSIQbxg+pbqDKrk2oxMK1rtLGVlKxcB9rrc6X5YjA==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.0.tgz",
+            "integrity": "sha512-Z3sfYEkLFzFmL8KY6xnSJLRxwQwYBjOXi/24lb62ZnZiGA0JUzGGTI6TBIgfCSMIDl9Jlu8SRmHNACLTemDHww==",
             "dev": true,
             "requires": {
                 "@sinonjs/formatio": "^3.1.0",
                 "@sinonjs/text-encoding": "^0.7.1",
                 "just-extend": "^4.0.2",
-                "lolex": "^2.3.2",
+                "lolex": "^4.1.0",
                 "path-to-regexp": "^1.7.0"
-            },
-            "dependencies": {
-                "lolex": {
-                    "version": "2.7.5",
-                    "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
-                    "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
-                    "dev": true
-                }
             }
         },
         "node-fetch": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
-            "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+            "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
             "dev": true
         },
         "node-rdkafka": {
@@ -5953,6 +5879,20 @@
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
             "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
             "dev": true
+        },
+        "npm-audit-resolver": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/npm-audit-resolver/-/npm-audit-resolver-1.5.0.tgz",
+            "integrity": "sha512-pOatk9mNIVqljbjlW8MqpeBWzF9TP9x7RMIyG+Z8i1RW0180w2h/+fhYruDzzLMLwe/FlLlk6uKSygUBVzjHFA==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.4.1",
+                "concat-stream": "^1.6.2",
+                "read": "^1.0.7",
+                "semver": "^5.5.0",
+                "spawn-shell": "^2.1.0",
+                "yargs-parser": "^10.0.0"
+            }
         },
         "npm-run-path": {
             "version": "2.0.2",
@@ -6027,6 +5967,26 @@
                 "isobject": "^3.0.0"
             }
         },
+        "object.assign": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+            "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.2",
+                "function-bind": "^1.1.1",
+                "has-symbols": "^1.0.0",
+                "object-keys": "^1.0.11"
+            },
+            "dependencies": {
+                "object-keys": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+                    "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+                    "dev": true
+                }
+            }
+        },
         "object.defaults": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
@@ -6036,6 +5996,30 @@
                 "array-slice": "^1.0.0",
                 "for-own": "^1.0.0",
                 "isobject": "^3.0.0"
+            }
+        },
+        "object.entries": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
+            "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.12.0",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3"
+            }
+        },
+        "object.fromentries": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.0.tgz",
+            "integrity": "sha512-9iLiI6H083uiqUuvzyY6qrlmc/Gz8hLQFOcb/Ri/0xXFkSNS3ctV+CbE6yM2+AnkYfOB3dGjdzC0wrMLIhQICA==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.2",
+                "es-abstract": "^1.11.0",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.1"
             }
         },
         "object.map": {
@@ -6053,6 +6037,18 @@
             "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
             "requires": {
                 "isobject": "^3.0.1"
+            }
+        },
+        "object.values": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
+            "integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.12.0",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3"
             }
         },
         "oer-utils": {
@@ -6193,9 +6189,9 @@
             }
         },
         "parent-module": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.0.tgz",
-            "integrity": "sha512-8Mf5juOMmiE4FcmzYc4IaiS9L3+9paz2KOiXzkRviCP6aDmN49Hz6EMWz0lGNp9pX80GvvAuLADtyGfW/Em3TA==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+            "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
             "dev": true,
             "requires": {
                 "callsites": "^3.0.0"
@@ -6331,26 +6327,70 @@
             }
         },
         "pkg-conf": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
-            "integrity": "sha1-ISZRTKbyq/69FoWW3xi6V4Z/AFg=",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-3.1.0.tgz",
+            "integrity": "sha512-m0OTbR/5VPNPqO1ph6Fqbj7Hv6QU7gR/tQW40ZqrL1rjgCU85W6C1bJn0BItuJqnR98PWzw7Z8hHeChD1WrgdQ==",
             "dev": true,
             "requires": {
-                "find-up": "^2.0.0",
-                "load-json-file": "^4.0.0"
+                "find-up": "^3.0.0",
+                "load-json-file": "^5.2.0"
             },
             "dependencies": {
-                "load-json-file": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-                    "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+                "find-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "parse-json": "^4.0.0",
-                        "pify": "^3.0.0",
-                        "strip-bom": "^3.0.0"
+                        "locate-path": "^3.0.0"
                     }
+                },
+                "load-json-file": {
+                    "version": "5.3.0",
+                    "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
+                    "integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.15",
+                        "parse-json": "^4.0.0",
+                        "pify": "^4.0.1",
+                        "strip-bom": "^3.0.0",
+                        "type-fest": "^0.3.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+                    "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^2.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.0.0"
+                    }
+                },
+                "p-try": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+                    "dev": true
                 },
                 "parse-json": {
                     "version": "4.0.0",
@@ -6363,9 +6403,9 @@
                     }
                 },
                 "pify": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+                    "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
                     "dev": true
                 },
                 "strip-bom": {
@@ -6388,9 +6428,9 @@
             },
             "dependencies": {
                 "xtend": {
-                    "version": "4.0.1",
-                    "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-                    "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+                    "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
                     "dev": true
                 }
             }
@@ -6491,23 +6531,23 @@
             }
         },
         "proxyquire": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.0.tgz",
-            "integrity": "sha512-kptdFArCfGRtQFv3Qwjr10lwbEV0TBJYvfqzhwucyfEXqVgmnAkyEw/S3FYzR5HI9i5QOq4rcqQjZ6AlknlCDQ==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.1.tgz",
+            "integrity": "sha512-LXZGUxkFTZzPHKBmL3CMYtYIEKuz6XiR3DZ3FZ1wYP7ueXbz2NW+9AdigNzeLIf8vmuhVCwG2F5BvonXK5LhHA==",
             "dev": true,
             "requires": {
                 "fill-keys": "^1.0.2",
-                "module-not-found-error": "^1.0.0",
-                "resolve": "~1.8.1"
+                "module-not-found-error": "^1.0.1",
+                "resolve": "^1.11.1"
             },
             "dependencies": {
                 "resolve": {
-                    "version": "1.8.1",
-                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-                    "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+                    "version": "1.11.1",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
+                    "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
                     "dev": true,
                     "requires": {
-                        "path-parse": "^1.0.5"
+                        "path-parse": "^1.0.6"
                     }
                 }
             }
@@ -6522,15 +6562,12 @@
             "resolved": "https://registry.npmjs.org/psl/-/psl-1.2.0.tgz",
             "integrity": "sha512-GEn74ZffufCmkDDLNcl3uuyF/aSD6exEyh1v/ZSdAomB82t6G9hzJVRx0jBmLDW+VfZqks3aScmMw9DszwUalA=="
         },
-<<<<<<< HEAD
         "pstree.remy": {
             "version": "1.1.7",
             "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.7.tgz",
             "integrity": "sha512-xsMgrUwRpuGskEzBFkH8NmTimbZ5PcPup0LA8JJkHIm2IMUbQcpo3yeLNWVrufEYjh8YwtSVh0xz6UeWc5Oh5A==",
             "dev": true
         },
-=======
->>>>>>> b19a35636787e12a664d79f8419d3081b514cfc0
         "pump": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
@@ -6606,10 +6643,19 @@
             }
         },
         "react-is": {
-            "version": "16.8.3",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.3.tgz",
-            "integrity": "sha512-Y4rC1ZJmsxxkkPuMLwvKvlL1Zfpbcu+Bf4ZigkHup3v9EfdYhAlWAaVyA19olXq2o2mGn0w+dFKvk3pVVlYcIA==",
+            "version": "16.8.6",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+            "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
             "dev": true
+        },
+        "read": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+            "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+            "dev": true,
+            "requires": {
+                "mute-stream": "~0.0.4"
+            }
         },
         "read-pkg": {
             "version": "2.0.0",
@@ -7204,9 +7250,9 @@
             }
         },
         "rxjs": {
-            "version": "6.4.0",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.4.0.tgz",
-            "integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
+            "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
             "dev": true,
             "requires": {
                 "tslib": "^1.9.0"
@@ -7300,16 +7346,16 @@
             }
         },
         "sinon": {
-            "version": "7.2.4",
-            "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.2.4.tgz",
-            "integrity": "sha512-FGlcfrkiBRfaEIKRw8s/9mk4nP4AMGswvKFixLo+AzsOhskjaBCHAHGLMd8pCJpQGS+9ZI71px6qoQUyvADeyA==",
+            "version": "7.3.2",
+            "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.3.2.tgz",
+            "integrity": "sha512-thErC1z64BeyGiPvF8aoSg0LEnptSaWE7YhdWWbWXgelOyThent7uKOnnEh9zBxDbKixtr5dEko+ws1sZMuFMA==",
             "dev": true,
             "requires": {
-                "@sinonjs/commons": "^1.3.0",
-                "@sinonjs/formatio": "^3.1.0",
-                "@sinonjs/samsam": "^3.1.1",
+                "@sinonjs/commons": "^1.4.0",
+                "@sinonjs/formatio": "^3.2.1",
+                "@sinonjs/samsam": "^3.3.1",
                 "diff": "^3.5.0",
-                "lolex": "^3.1.0",
+                "lolex": "^4.0.1",
                 "nise": "^1.4.10",
                 "supports-color": "^5.5.0"
             }
@@ -7457,6 +7503,17 @@
             "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
             "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
         },
+        "spawn-shell": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/spawn-shell/-/spawn-shell-2.1.0.tgz",
+            "integrity": "sha512-mjlYAQbZPHd4YsoHEe+i0Xbp9sJefMKN09JPp80TqrjC5NSuo+y1RG3NBireJlzl1dDV2NIkIfgS6coXtyqN/A==",
+            "dev": true,
+            "requires": {
+                "default-shell": "^1.0.1",
+                "merge-options": "~1.0.1",
+                "npm-run-path": "^2.0.2"
+            }
+        },
         "spawn-sync": {
             "version": "1.0.15",
             "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
@@ -7494,9 +7551,9 @@
             }
         },
         "spdx-license-ids": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
-            "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+            "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
             "dev": true
         },
         "split-string": {
@@ -7545,216 +7602,32 @@
             "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
         },
         "standard": {
-            "version": "12.0.1",
-            "resolved": "https://registry.npmjs.org/standard/-/standard-12.0.1.tgz",
-            "integrity": "sha512-UqdHjh87OG2gUrNCSM4QRLF5n9h3TFPwrCNyVlkqu31Hej0L/rc8hzKqVvkb2W3x0WMq7PzZdkLfEcBhVOR6lg==",
+            "version": "13.0.2",
+            "resolved": "https://registry.npmjs.org/standard/-/standard-13.0.2.tgz",
+            "integrity": "sha512-tcdJc7Oa+ZFpIcYqNaV3kG3Ikqk1Ir5dCn8vaiLWvDcXdRGvQVQGbTqW/3y4RPEHXGBXoZZRQbb6VbSGx+0aqg==",
             "dev": true,
             "requires": {
-                "eslint": "~5.4.0",
-                "eslint-config-standard": "12.0.0",
-                "eslint-config-standard-jsx": "6.0.2",
-                "eslint-plugin-import": "~2.14.0",
-                "eslint-plugin-node": "~7.0.1",
-                "eslint-plugin-promise": "~4.0.0",
-                "eslint-plugin-react": "~7.11.1",
+                "eslint": "~6.0.1",
+                "eslint-config-standard": "13.0.1",
+                "eslint-config-standard-jsx": "7.0.0",
+                "eslint-plugin-import": "~2.18.0",
+                "eslint-plugin-node": "~9.1.0",
+                "eslint-plugin-promise": "~4.2.1",
+                "eslint-plugin-react": "~7.14.2",
                 "eslint-plugin-standard": "~4.0.0",
-                "standard-engine": "~9.0.0"
-            },
-            "dependencies": {
-                "ajv-keywords": {
-                    "version": "3.4.0",
-                    "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.0.tgz",
-                    "integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==",
-                    "dev": true
-                },
-                "chardet": {
-                    "version": "0.4.2",
-                    "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-                    "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
-                    "dev": true
-                },
-                "debug": {
-                    "version": "3.2.6",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
-                "doctrine": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-                    "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-                    "dev": true,
-                    "requires": {
-                        "esutils": "^2.0.2"
-                    }
-                },
-                "eslint": {
-                    "version": "5.4.0",
-                    "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.4.0.tgz",
-                    "integrity": "sha512-UIpL91XGex3qtL6qwyCQJar2j3osKxK9e3ano3OcGEIRM4oWIpCkDg9x95AXEC2wMs7PnxzOkPZ2gq+tsMS9yg==",
-                    "dev": true,
-                    "requires": {
-                        "ajv": "^6.5.0",
-                        "babel-code-frame": "^6.26.0",
-                        "chalk": "^2.1.0",
-                        "cross-spawn": "^6.0.5",
-                        "debug": "^3.1.0",
-                        "doctrine": "^2.1.0",
-                        "eslint-scope": "^4.0.0",
-                        "eslint-utils": "^1.3.1",
-                        "eslint-visitor-keys": "^1.0.0",
-                        "espree": "^4.0.0",
-                        "esquery": "^1.0.1",
-                        "esutils": "^2.0.2",
-                        "file-entry-cache": "^2.0.0",
-                        "functional-red-black-tree": "^1.0.1",
-                        "glob": "^7.1.2",
-                        "globals": "^11.7.0",
-                        "ignore": "^4.0.2",
-                        "imurmurhash": "^0.1.4",
-                        "inquirer": "^5.2.0",
-                        "is-resolvable": "^1.1.0",
-                        "js-yaml": "^3.11.0",
-                        "json-stable-stringify-without-jsonify": "^1.0.1",
-                        "levn": "^0.3.0",
-                        "lodash": "^4.17.5",
-                        "minimatch": "^3.0.4",
-                        "mkdirp": "^0.5.1",
-                        "natural-compare": "^1.4.0",
-                        "optionator": "^0.8.2",
-                        "path-is-inside": "^1.0.2",
-                        "pluralize": "^7.0.0",
-                        "progress": "^2.0.0",
-                        "regexpp": "^2.0.0",
-                        "require-uncached": "^1.0.3",
-                        "semver": "^5.5.0",
-                        "strip-ansi": "^4.0.0",
-                        "strip-json-comments": "^2.0.1",
-                        "table": "^4.0.3",
-                        "text-table": "^0.2.0"
-                    }
-                },
-                "espree": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/espree/-/espree-4.1.0.tgz",
-                    "integrity": "sha512-I5BycZW6FCVIub93TeVY1s7vjhP9CY6cXCznIRfiig7nRviKZYdRnj/sHEWC6A7WE9RDWOFq9+7OsWSYz8qv2w==",
-                    "dev": true,
-                    "requires": {
-                        "acorn": "^6.0.2",
-                        "acorn-jsx": "^5.0.0",
-                        "eslint-visitor-keys": "^1.0.0"
-                    }
-                },
-                "external-editor": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-                    "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
-                    "dev": true,
-                    "requires": {
-                        "chardet": "^0.4.0",
-                        "iconv-lite": "^0.4.17",
-                        "tmp": "^0.0.33"
-                    }
-                },
-                "file-entry-cache": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-                    "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
-                    "dev": true,
-                    "requires": {
-                        "flat-cache": "^1.2.1",
-                        "object-assign": "^4.0.1"
-                    }
-                },
-                "flat-cache": {
-                    "version": "1.3.4",
-                    "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
-                    "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
-                    "dev": true,
-                    "requires": {
-                        "circular-json": "^0.3.1",
-                        "graceful-fs": "^4.1.2",
-                        "rimraf": "~2.6.2",
-                        "write": "^0.2.1"
-                    }
-                },
-                "inquirer": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
-                    "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-escapes": "^3.0.0",
-                        "chalk": "^2.0.0",
-                        "cli-cursor": "^2.1.0",
-                        "cli-width": "^2.0.0",
-                        "external-editor": "^2.1.0",
-                        "figures": "^2.0.0",
-                        "lodash": "^4.3.0",
-                        "mute-stream": "0.0.7",
-                        "run-async": "^2.2.0",
-                        "rxjs": "^5.5.2",
-                        "string-width": "^2.1.0",
-                        "strip-ansi": "^4.0.0",
-                        "through": "^2.3.6"
-                    }
-                },
-                "rxjs": {
-                    "version": "5.5.12",
-                    "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
-                    "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
-                    "dev": true,
-                    "requires": {
-                        "symbol-observable": "1.0.1"
-                    }
-                },
-                "slice-ansi": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-                    "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
-                    "dev": true,
-                    "requires": {
-                        "is-fullwidth-code-point": "^2.0.0"
-                    }
-                },
-                "table": {
-                    "version": "4.0.3",
-                    "resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
-                    "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
-                    "dev": true,
-                    "requires": {
-                        "ajv": "^6.0.1",
-                        "ajv-keywords": "^3.0.0",
-                        "chalk": "^2.1.0",
-                        "lodash": "^4.17.4",
-                        "slice-ansi": "1.0.0",
-                        "string-width": "^2.1.1"
-                    }
-                },
-                "write": {
-                    "version": "0.2.1",
-                    "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-                    "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-                    "dev": true,
-                    "requires": {
-                        "mkdirp": "^0.5.1"
-                    }
-                }
+                "standard-engine": "~11.0.1"
             }
         },
         "standard-engine": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-9.0.0.tgz",
-            "integrity": "sha512-ZfNfCWZ2Xq67VNvKMPiVMKHnMdvxYzvZkf1AH8/cw2NLDBm5LRsxMqvEJpsjLI/dUosZ3Z1d6JlHDp5rAvvk2w==",
+            "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-11.0.1.tgz",
+            "integrity": "sha512-WZQ5PpEDfRzPFk+H9xvKVQPQIxKnAQB2cb2Au4NyTCtdw5R0pyMBUZLbPXyFjnlhe8Ae+zfNrWU4m6H5b7cEAg==",
             "dev": true,
             "requires": {
-                "deglob": "^2.1.0",
-                "get-stdin": "^6.0.0",
+                "deglob": "^3.0.0",
+                "get-stdin": "^7.0.0",
                 "minimist": "^1.1.0",
-                "pkg-conf": "^2.0.0"
+                "pkg-conf": "^3.1.0"
             }
         },
         "static-extend": {
@@ -7973,48 +7846,42 @@
                 }
             }
         },
-        "symbol-observable": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
-            "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
-            "dev": true
-        },
         "table": {
-            "version": "5.2.3",
-            "resolved": "https://registry.npmjs.org/table/-/table-5.2.3.tgz",
-            "integrity": "sha512-N2RsDAMvDLvYwFcwbPyF3VmVSSkuF+G1e+8inhBLtHpvwXGw4QRPEZhihQNeEN0i1up6/f6ObCJXNdlRG3YVyQ==",
+            "version": "5.4.4",
+            "resolved": "https://registry.npmjs.org/table/-/table-5.4.4.tgz",
+            "integrity": "sha512-IIfEAUx5QlODLblLrGTTLJA7Tk0iLSGBvgY8essPRVNGHAzThujww1YqHLs6h3HfTg55h++RzLHH5Xw/rfv+mg==",
             "dev": true,
             "requires": {
-                "ajv": "^6.9.1",
-                "lodash": "^4.17.11",
+                "ajv": "^6.10.2",
+                "lodash": "^4.17.14",
                 "slice-ansi": "^2.1.0",
                 "string-width": "^3.0.0"
             },
             "dependencies": {
                 "ansi-regex": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
-                    "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
                     "dev": true
                 },
                 "string-width": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.0.0.tgz",
-                    "integrity": "sha512-rr8CUxBbvOZDUvc5lNIJ+OC1nPVpz+Siw9VBtUjB9b6jZehZLFt0JMCZzShFHIsI8cbhm0EsNIfWJMFV3cu3Ew==",
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
                     "dev": true,
                     "requires": {
                         "emoji-regex": "^7.0.1",
                         "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^5.0.0"
+                        "strip-ansi": "^5.1.0"
                     }
                 },
                 "strip-ansi": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
-                    "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^4.0.0"
+                        "ansi-regex": "^4.1.0"
                     }
                 }
             }
@@ -8061,9 +7928,9 @@
             }
         },
         "tap-xunit": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/tap-xunit/-/tap-xunit-2.3.0.tgz",
-            "integrity": "sha512-YVsURNvn1wfVUWb5wjansxhfbfeo2hOBTUbVgZoaMO8lyZzpiSi9IiZTZ7JG56m6A49LeWjfJIx/SnAre41V/A==",
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tap-xunit/-/tap-xunit-2.4.1.tgz",
+            "integrity": "sha512-qcZStDtjjYjMKAo7QNiCtOW256g3tuSyCSe5kNJniG1Q2oeOExJq4vm8CwboHZURpkXAHvtqMl4TVL7mcbMVVA==",
             "dev": true,
             "requires": {
                 "duplexer": "~0.1.1",
@@ -8121,29 +7988,29 @@
                     }
                 },
                 "xtend": {
-                    "version": "4.0.1",
-                    "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-                    "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+                    "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
                     "dev": true
                 }
             }
         },
         "tape": {
-            "version": "4.10.1",
-            "resolved": "https://registry.npmjs.org/tape/-/tape-4.10.1.tgz",
-            "integrity": "sha512-G0DywYV1jQeY3axeYnXUOt6ktnxS9OPJh97FGR3nrua8lhWi1zPflLxcAHavZ7Jf3qUfY7cxcVIVFa4mY2IY1w==",
+            "version": "4.11.0",
+            "resolved": "https://registry.npmjs.org/tape/-/tape-4.11.0.tgz",
+            "integrity": "sha512-yixvDMX7q7JIs/omJSzSZrqulOV51EC9dK8dM0TzImTIkHWfe2/kFyL5v+d9C+SrCMaICk59ujsqFAVidDqDaA==",
             "dev": true,
             "requires": {
                 "deep-equal": "~1.0.1",
                 "defined": "~1.0.0",
                 "for-each": "~0.3.3",
                 "function-bind": "~1.1.1",
-                "glob": "~7.1.3",
+                "glob": "~7.1.4",
                 "has": "~1.0.3",
-                "inherits": "~2.0.3",
+                "inherits": "~2.0.4",
                 "minimist": "~1.2.0",
                 "object-inspect": "~1.6.0",
-                "resolve": "~1.10.0",
+                "resolve": "~1.11.1",
                 "resumer": "~0.0.0",
                 "string.prototype.trim": "~1.1.2",
                 "through": "~2.3.8"
@@ -8160,6 +8027,35 @@
                     "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
                     "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
                     "dev": true
+                },
+                "glob": {
+                    "version": "7.1.4",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+                    "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                },
+                "inherits": {
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+                    "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+                    "dev": true
+                },
+                "resolve": {
+                    "version": "1.11.1",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
+                    "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+                    "dev": true,
+                    "requires": {
+                        "path-parse": "^1.0.6"
+                    }
                 }
             }
         },
@@ -8349,7 +8245,6 @@
                 "hoek": "6.x.x"
             }
         },
-<<<<<<< HEAD
         "touch": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
@@ -8370,8 +8265,6 @@
                 }
             }
         },
-=======
->>>>>>> b19a35636787e12a664d79f8419d3081b514cfc0
         "tough-cookie": {
             "version": "2.4.3",
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
@@ -8415,9 +8308,9 @@
             "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
         },
         "tslib": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-            "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+            "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
             "dev": true
         },
         "tunnel-agent": {
@@ -8446,6 +8339,12 @@
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
             "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+            "dev": true
+        },
+        "type-fest": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+            "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
             "dev": true
         },
         "typedarray": {
@@ -8546,7 +8445,6 @@
             "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
             "dev": true
         },
-<<<<<<< HEAD
         "unique-string": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
@@ -8556,8 +8454,6 @@
                 "crypto-random-string": "^1.0.0"
             }
         },
-=======
->>>>>>> b19a35636787e12a664d79f8419d3081b514cfc0
         "unpipe": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -8915,6 +8811,15 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
             "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+        },
+        "yargs-parser": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+            "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+            "dev": true,
+            "requires": {
+                "camelcase": "^4.1.0"
+            }
         },
         "z-schema": {
             "version": "3.25.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "central-settlement",
     "description": "Central settlements hosted by a scheme to record and make settlements",
-    "version": "7.1.1",
+    "version": "7.1.2",
     "license": "Apache-2.0",
     "private": true,
     "author": "ModusBox",
@@ -26,7 +26,7 @@
         "@mojaloop/central-ledger": "5.2.1",
         "@mojaloop/central-services-auth": "5.2.1",
         "@mojaloop/central-services-database": "5.2.1",
-        "@mojaloop/central-services-error-handling": "7.1.1",
+        "@mojaloop/central-services-error-handling": "7.1.2",
         "@mojaloop/central-services-health": "7.0.0",
         "@mojaloop/central-services-shared": "6.4.1",
         "@mojaloop/central-services-stream": "6.2.2",
@@ -39,20 +39,21 @@
     },
     "devDependencies": {
         "@hapi/joi": "15.1.0",
-        "bluebird": "3.5.3",
-        "eslint": "5.14.1",
+        "bluebird": "3.5.5",
+        "eslint": "6.0.1",
         "faucet": "0.0.1",
         "istanbul": "1.1.0-alpha.1",
-        "node-fetch": "2.3.0",
+        "npm-audit-resolver": "1.5.0",
+        "node-fetch": "2.6.0",
         "nodemon": "1.19.1",
         "pre-commit": "1.2.2",
-        "proxyquire": "2.1.0",
+        "proxyquire": "2.1.1",
         "rewire": "4.0.1",
-        "sinon": "7.2.4",
-        "standard": "12.0.1",
+        "sinon": "7.3.2",
+        "standard": "13.0.2",
         "swagmock": "1.0.0",
-        "tap-xunit": "2.3.0",
-        "tape": "4.10.1",
+        "tap-xunit": "2.4.1",
+        "tape": "4.11.0",
         "tapes": "4.1.0"
     },
     "scripts": {
@@ -69,7 +70,9 @@
         "test:coverage": "istanbul cover tape -- 'test/unit/**/*.js'",
         "test:int": "tape 'test/integration/**/*.test.js'",
         "test:integration": "sh ./test/integration-runner.sh ./test/integration-runner.env",
-        "regenerate": "yo swaggerize:test --framework hapi --apiPath './src/interface/swagger.json'"
+        "regenerate": "yo swaggerize:test --framework hapi --apiPath './src/interface/swagger.json'",
+        "audit:resolve": "SHELL=sh resolve-audit",
+        "audit:check": "SHELL=sh check-audit"
     },
     "generator-swaggerize": {
         "version": "4.1.0"


### PR DESCRIPTION
Part of: mojaloop/project#801

Adds 2 new steps to the ci process:
- `vunerability-check`: uses npm audit to check for and resolve vulnerabilities in packages
- `audit-license`: checks for disallowed or unknown licenses using the license-scanner tool
