### PR TITLE
Fixed cache issue with checksum calculation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
           command: cd $(npm root -g)/npm
       - run:
           name: Install interledgerjs/five-bells-ledger-api-tests
-          command: npm install github:interledgerjs/five-bells-ledger-api-tests
+          command: npm install --no-save github:interledgerjs/five-bells-ledger-api-tests
       - run:
           name: Update NPM install
           command: npm install
@@ -96,7 +96,6 @@ jobs:
       - restore_cache:
           keys:
             - dependency-cache-{{ checksum "package.json" }}
-            - dependency-cache-
       - run:
           name: Create dir for test results
           command: mkdir -p ./test/results
@@ -128,7 +127,6 @@ jobs:
       - restore_cache:
           keys:
             - dependency-cache-{{ checksum "package.json" }}
-            - dependency-cache-
       - run:
           name: Execute code coverage check
           command: npm -s run test:coverage
@@ -153,7 +151,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ checksum "CACHE_VERSION.txt" }}-{{ checksum "package.json" }}
+          key: dependency-cache-{{ checksum "package.json" }}
       - run:
           name: Create dir for test results
           command: mkdir -p ./test/results
@@ -176,7 +174,6 @@ jobs:
       - restore_cache:
           keys:
             - dependency-cache-{{ checksum "package.json" }}
-            - dependency-cache-
       - run:
           name: Create dir for test results
           command: mkdir -p ./audit/results
@@ -199,7 +196,6 @@ jobs:
       - restore_cache:
           keys:
             - dependency-cache-{{ checksum "package.json" }}
-            - dependency-cache-
       - run:
           name: Prune non-production packages before running license-scanner
           command: npm prune --production


### PR DESCRIPTION
**Problem:** The _"npm install interledger..."_ statement in the setup step is altering the package.json hence it is saving cache at a different key based on the new checksum. While restoring the cache in the other steps are based on the original package.json. So it is picking up the cache from previous builds.

**Fix:** Added _"--no-save"_ option for npm install statement in setup