### PR TITLE
fix: Core handler services that have a dependency on central-services-database are not loading all tables on startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,7 @@ jspm_packages
 .history
 /.gitlab-ci.env
 junit.xml
+
+# Add ignores
+*IGNORE*
+*ignore*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "central-settlement",
-    "version": "12.0.1",
+    "version": "12.0.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -1552,6 +1552,33 @@
                         "lodash": "4.17.20"
                     }
                 },
+                "@now-ims/hapi-now-auth": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/@now-ims/hapi-now-auth/-/hapi-now-auth-2.0.2.tgz",
+                    "integrity": "sha512-fOhJUE5g6dO6SEen8HgH8Ty7KT9juwZhg8IQ4xqECDWJK84t/wDmCUWOSFyQTmzDIXa4RSja1edfJUZRv5zNtw==",
+                    "requires": {
+                        "@hapi/boom": "^7.4.11",
+                        "@hapi/hoek": "^9.0.2",
+                        "jsonwebtoken": "^8.5.1"
+                    },
+                    "dependencies": {
+                        "@hapi/boom": {
+                            "version": "7.4.11",
+                            "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.11.tgz",
+                            "integrity": "sha512-VSU/Cnj1DXouukYxxkes4nNJonCnlogHvIff1v1RVoN4xzkKhMXX+GRmb3NyH1iar10I9WFPDv2JPwfH3GaV0A==",
+                            "requires": {
+                                "@hapi/hoek": "8.x.x"
+                            },
+                            "dependencies": {
+                                "@hapi/hoek": {
+                                    "version": "8.5.1",
+                                    "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
+                                    "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow=="
+                                }
+                            }
+                        }
+                    }
+                },
                 "decimal.js": {
                     "version": "10.2.1",
                     "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
@@ -2528,12 +2555,13 @@
             }
         },
         "@now-ims/hapi-now-auth": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@now-ims/hapi-now-auth/-/hapi-now-auth-2.0.2.tgz",
-            "integrity": "sha512-fOhJUE5g6dO6SEen8HgH8Ty7KT9juwZhg8IQ4xqECDWJK84t/wDmCUWOSFyQTmzDIXa4RSja1edfJUZRv5zNtw==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@now-ims/hapi-now-auth/-/hapi-now-auth-2.0.3.tgz",
+            "integrity": "sha512-41q0Y9ybnqIbJg/3kOx5Tq7k/5avt0XaqnnISuCIa+9ZFSREK0fhnp8RPA169WahoREAJUg5b4bKY90B6lb9Og==",
             "requires": {
                 "@hapi/boom": "^7.4.11",
                 "@hapi/hoek": "^9.0.2",
+                "joi": "^17.4.0",
                 "jsonwebtoken": "^8.5.1"
             },
             "dependencies": {
@@ -2550,6 +2578,18 @@
                             "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
                             "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow=="
                         }
+                    }
+                },
+                "joi": {
+                    "version": "17.4.0",
+                    "resolved": "https://registry.npmjs.org/joi/-/joi-17.4.0.tgz",
+                    "integrity": "sha512-F4WiW2xaV6wc1jxete70Rw4V/VuMd6IN+a5ilZsxG4uYtUXWu2kq9W5P2dz30e7Gmw8RCbY/u/uk+dMPma9tAg==",
+                    "requires": {
+                        "@hapi/hoek": "^9.0.0",
+                        "@hapi/topo": "^5.0.0",
+                        "@sideway/address": "^4.1.0",
+                        "@sideway/formula": "^3.0.0",
+                        "@sideway/pinpoint": "^2.0.0"
                     }
                 }
             }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "central-settlement",
     "description": "Central settlements hosted by a scheme to record and make settlements.",
-    "version": "12.0.1",
+    "version": "12.0.2",
     "license": "Apache-2.0",
     "private": false,
     "author": "ModusBox",
@@ -38,7 +38,7 @@
         "@mojaloop/central-services-shared": "11.5.5",
         "@mojaloop/central-services-stream": "10.6.0",
         "@mojaloop/ml-number": "11.0.0",
-        "@now-ims/hapi-now-auth": "2.0.2",
+        "@now-ims/hapi-now-auth": "2.0.3",
         "async": "3.2.0",
         "async-retry": "1.3.1",
         "bignumber.js": "9.0.1",
@@ -83,7 +83,7 @@
         "tapes": "4.1.0"
     },
     "pre-commit": [
-        "standard",
+        "lint",
         "dep:check",
         "test"
     ],
@@ -93,8 +93,9 @@
         "watch:api": "nodemon src/api/index.js",
         "start:handlers": "node src/handlers/index.js",
         "regenerate": "yo swaggerize:test --framework hapi --apiPath './src/interface/swagger.yaml'",
-        "standard": "standard",
-        "lint": "eslint .",
+        "lint": "standard",
+        "lint:fix": "standard --fix",
+        "eslint": "eslint .",
         "test": "npm run test:unit | faucet",
         "test:all": "run-s test",
         "test:unit": "tape 'test/unit/**/*.test.js'",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "pre-commit": [
         "lint",
         "dep:check",
-        "test"
+        "test:unit"
     ],
     "scripts": {
         "start": "run-p start:api",

--- a/src/models/ilpPackets/ilpPacket.js
+++ b/src/models/ilpPackets/ilpPacket.js
@@ -29,7 +29,7 @@ const ErrorHandler = require('@mojaloop/central-services-error-handling')
 
 exports.getById = async (id) => {
   try {
-    return await Db.ilpPacket.find({ transferId: id })
+    return await Db.from('ilpPacket').find({ transferId: id })
   } catch (err) {
     throw ErrorHandler.Factory.reformatFSPIOPError(err)
   }

--- a/src/models/lib/enums.js
+++ b/src/models/lib/enums.js
@@ -37,7 +37,7 @@ module.exports = {
 
   ledgerAccountTypes: async function () {
     const ledgerAccountTypeEnum = {}
-    const ledgerAccountTypeEnumsList = await Db.ledgerAccountType.find({})
+    const ledgerAccountTypeEnumsList = await Db.from('ledgerAccountType').find({})
     if (ledgerAccountTypeEnumsList) {
       for (const state of ledgerAccountTypeEnumsList) {
         ledgerAccountTypeEnum[`${state.name}`] = state.ledgerAccountTypeId
@@ -47,7 +47,7 @@ module.exports = {
   },
   ledgerEntryTypes: async function () {
     const ledgerEntryTypeEnum = {}
-    const ledgerEntryTypeEnumsList = await Db.ledgerEntryType.find({})
+    const ledgerEntryTypeEnumsList = await Db.from('ledgerEntryType').find({})
     if (ledgerEntryTypeEnumsList) {
       for (const state of ledgerEntryTypeEnumsList) {
         ledgerEntryTypeEnum[`${state.name}`] = state.ledgerEntryTypeId
@@ -57,7 +57,7 @@ module.exports = {
   },
   participantLimitTypes: async function () {
     const participantLimitTypeEnum = {}
-    const participantLimitTypeEnumsList = await Db.participantLimitType.find({})
+    const participantLimitTypeEnumsList = await Db.from('participantLimitType').find({})
     if (participantLimitTypeEnumsList) {
       for (const state of participantLimitTypeEnumsList) {
         participantLimitTypeEnum[`${state.name}`] = state.participantLimitTypeId
@@ -68,7 +68,7 @@ module.exports = {
   settlementDelay: async function () {
     const settlementDelayName = {}
 
-    const settlementDelayNamesList = await Db.settlementDelay.find({})
+    const settlementDelayNamesList = await Db.from('settlementDelay').find({})
     if (settlementDelayNamesList) {
       for (const record of settlementDelayNamesList) {
         settlementDelayName[`${record.name}`] = record.settlementDelayId
@@ -79,7 +79,7 @@ module.exports = {
   settlementDelayEnums: async function () {
     const settlementDelayEnum = {}
 
-    const settlementDelayEnumsList = await Db.settlementDelay.find({})
+    const settlementDelayEnumsList = await Db.from('settlementDelay').find({})
     if (settlementDelayEnumsList) {
       for (const record of settlementDelayEnumsList) {
         settlementDelayEnum[`${record.name}`] = record.name
@@ -90,7 +90,7 @@ module.exports = {
   settlementGranularity: async function () {
     const settlementGranularityName = {}
 
-    const settlementGranularityNamesList = await Db.settlementGranularity.find({})
+    const settlementGranularityNamesList = await Db.from('settlementGranularity').find({})
     if (settlementGranularityNamesList) {
       for (const record of settlementGranularityNamesList) {
         settlementGranularityName[`${record.name}`] = record.settlementGranularityId
@@ -101,7 +101,7 @@ module.exports = {
   settlementGranularityEnums: async function () {
     const settlementGranularityEnum = {}
 
-    const settlementGranularityEnumsList = await Db.settlementGranularity.find({})
+    const settlementGranularityEnumsList = await Db.from('settlementGranularity').find({})
     if (settlementGranularityEnumsList) {
       for (const record of settlementGranularityEnumsList) {
         settlementGranularityEnum[`${record.name}`] = record.name
@@ -112,7 +112,7 @@ module.exports = {
   settlementInterchange: async function () {
     const settlementInterchangeName = {}
 
-    const settlementInterchangeNamesList = await Db.settlementInterchange.find({})
+    const settlementInterchangeNamesList = await Db.from('settlementInterchange').find({})
     if (settlementInterchangeNamesList) {
       for (const record of settlementInterchangeNamesList) {
         settlementInterchangeName[`${record.name}`] = record.settlementInterchangeId
@@ -123,7 +123,7 @@ module.exports = {
   settlementInterchangeEnums: async function () {
     const settlementInterchangeEnum = {}
 
-    const settlementInterchangeEnumsList = await Db.settlementInterchange.find({})
+    const settlementInterchangeEnumsList = await Db.from('settlementInterchange').find({})
     if (settlementInterchangeEnumsList) {
       for (const record of settlementInterchangeEnumsList) {
         settlementInterchangeEnum[`${record.name}`] = record.name
@@ -134,7 +134,7 @@ module.exports = {
   settlementStates: async function () {
     const settlementStateEnum = {}
 
-    const settlementStateEnumsList = await Db.settlementState.find({})
+    const settlementStateEnumsList = await Db.from('settlementState').find({})
     if (settlementStateEnumsList) {
       for (const state of settlementStateEnumsList) {
         settlementStateEnum[`${state.enumeration}`] = state.settlementStateId
@@ -144,7 +144,7 @@ module.exports = {
   },
   settlementWindowStates: async function () {
     const settlementWindowStateEnum = {}
-    const settlementWindowStateEnumsList = await Db.settlementWindowState.find({})
+    const settlementWindowStateEnumsList = await Db.from('settlementWindowState').find({})
     if (settlementWindowStateEnumsList) {
       for (const state of settlementWindowStateEnumsList) {
         settlementWindowStateEnum[`${state.enumeration}`] = state.settlementWindowStateId
@@ -154,7 +154,7 @@ module.exports = {
   },
   transferParticipantRoleTypes: async function () {
     const transferParticipantRoleTypeEnum = {}
-    const transferParticipantRoleTypeEnumsList = await Db.transferParticipantRoleType.find({})
+    const transferParticipantRoleTypeEnumsList = await Db.from('transferParticipantRoleType').find({})
     if (transferParticipantRoleTypeEnumsList) {
       for (const state of transferParticipantRoleTypeEnumsList) {
         transferParticipantRoleTypeEnum[`${state.name}`] = state.transferParticipantRoleTypeId
@@ -164,7 +164,7 @@ module.exports = {
   },
   transferStateEnums: async function () {
     const transferStateEnum = {}
-    const transferStateEnumsList = await Db.transferState.find({})
+    const transferStateEnumsList = await Db.from('transferState').find({})
     if (transferStateEnumsList) {
       for (const state of transferStateEnumsList) {
         // apply distinct even though final result would contain distinct values
@@ -177,7 +177,7 @@ module.exports = {
   },
   transferStates: async function () {
     const transferStateEnum = {}
-    const transferStateEnumsList = await Db.transferState.find({})
+    const transferStateEnumsList = await Db.from('transferState').find({})
     if (transferStateEnumsList) {
       for (const state of transferStateEnumsList) {
         transferStateEnum[`${state.transferStateId}`] = state.transferStateId

--- a/src/models/misc/migrationLock.js
+++ b/src/models/misc/migrationLock.js
@@ -33,7 +33,7 @@ const Db = require('../../lib/db')
  * @returns {Promise<boolean>} - true if locked, false if not. Rejects if an error occours
  */
 const getIsMigrationLocked = async () => {
-  const result = await Db.migration_lock.query(async builder => {
+  const result = await Db.from('migration_lock').query(async builder => {
     builder.select('is_locked AS isLocked')
       .orderBy('index', 'desc')
       .first()

--- a/src/models/settlement/facade.js
+++ b/src/models/settlement/facade.js
@@ -1330,7 +1330,7 @@ const Facade = {
   },
 
   getById: async function ({ settlementId }) {
-    return Db.settlement.query(builder => {
+    return Db.from('settlement').query(builder => {
       return builder
         .join('settlementStateChange AS ssc', 'ssc.settlementStateChangeId', 'settlement.currentStateChangeId')
         .select('settlement.settlementId',
@@ -1345,7 +1345,7 @@ const Facade = {
   },
 
   getByParams: async function ({ state, fromDateTime, toDateTime, currency, settlementWindowId, fromSettlementWindowDateTime, toSettlementWindowDateTime, participantId, accountId }) {
-    return Db.settlement.query(builder => {
+    return Db.from('settlement').query(builder => {
       const b = builder
         .innerJoin('settlementStateChange AS ssc', 'ssc.settlementStateChangeId', 'settlement.currentStateChangeId')
         .innerJoin('settlementSettlementWindow AS ssw', 'ssw.settlementId', 'settlement.settlementId')
@@ -1537,7 +1537,7 @@ const Facade = {
 
   settlementParticipantCurrency: {
     getByListOfIds: async function (listOfIds) {
-      return Db.settlementParticipantCurrency.query(builder => {
+      return Db.from('settlementParticipantCurrency').query(builder => {
         return builder
           .leftJoin('participantCurrency AS pc', 'pc.participantCurrencyId', 'settlementParticipantCurrency.participantCurrencyId')
           .leftJoin('participant as p', 'p.participantCurrencyId', 'pc.participantCurrencyId')
@@ -1551,7 +1551,7 @@ const Facade = {
     },
 
     getAccountsInSettlementByIds: async function ({ settlementId, participantId }) {
-      return Db.settlementParticipantCurrency.query(builder => {
+      return Db.from('settlementParticipantCurrency').query(builder => {
         return builder
           .join('participantCurrency AS pc', 'pc.participantCurrencyId', 'settlementParticipantCurrency.participantCurrencyId')
           .select('settlementParticipantCurrencyId')
@@ -1561,7 +1561,7 @@ const Facade = {
     },
 
     getParticipantCurrencyBySettlementId: async function ({ settlementId }) {
-      return Db.settlementParticipantCurrency.query(builder => {
+      return Db.from('settlementParticipantCurrency').query(builder => {
         return builder
           .leftJoin('settlementParticipantCurrencyStateChange AS spcsc', 'spcsc.settlementParticipantCurrencyStateChangeId', 'settlementParticipantCurrency.currentStateChangeId')
           .join('participantCurrency AS pc', 'pc.participantCurrencyId', 'settlementParticipantCurrency.participantCurrencyId')
@@ -1579,7 +1579,7 @@ const Facade = {
     },
 
     getSettlementAccountById: async function (settlementParticipantCurrencyId) {
-      return Db.settlementParticipantCurrency.query(builder => {
+      return Db.from('settlementParticipantCurrency').query(builder => {
         return builder
           .join('settlementParticipantCurrencyStateChange AS spcsc', 'spcsc.settlementParticipantCurrencyStateChangeId', 'settlementParticipantCurrency.currentStateChangeId')
           .join('participantCurrency AS pc', 'pc.participantCurrencyId', 'settlementParticipantCurrency.participantCurrencyId')
@@ -1596,7 +1596,7 @@ const Facade = {
     },
 
     getSettlementAccountsByListOfIds: async function (settlementParticipantCurrencyIdList) {
-      return Db.settlementParticipantCurrency.query(builder => {
+      return Db.from('settlementParticipantCurrency').query(builder => {
         return builder
           .join('settlementParticipantCurrencyStateChange AS spcsc', 'spcsc.settlementParticipantCurrencyStateChangeId', 'settlementParticipantCurrency.currentStateChangeId')
           .join('participantCurrency AS pc', 'pc.participantCurrencyId', 'settlementParticipantCurrency.participantCurrencyId')
@@ -1614,7 +1614,7 @@ const Facade = {
   },
   settlementSettlementWindow: {
     getWindowsBySettlementIdAndAccountId: async function ({ settlementId, accountId }) {
-      return Db.settlementSettlementWindow.query(builder => {
+      return Db.from('settlementSettlementWindow').query(builder => {
         return builder
           .join('settlementWindow', 'settlementWindow.settlementWindowId', 'settlementSettlementWindow.settlementWindowId')
           .join('settlementWindowStateChange AS swsc', 'swsc.settlementWindowStateChangeId', 'settlementWindow.currentStateChangeId')
@@ -1635,8 +1635,8 @@ const Facade = {
     },
 
     getWindowsBySettlementIdAndParticipantId: async function ({ settlementId, participantId }, enums) {
-      const participantAccountList = (await Db.participantCurrency.find({ participantId, ledgerAccountTypeId: enums.ledgerAccountTypes.POSITION })).map(record => record.participantCurrencyId)
-      return Db.settlementSettlementWindow.query(builder => {
+      const participantAccountList = (await Db.from('participantCurrency').find({ participantId, ledgerAccountTypeId: enums.ledgerAccountTypes.POSITION })).map(record => record.participantCurrencyId)
+      return Db.from('settlementSettlementWindow').query(builder => {
         return builder
           .join('settlementWindow', 'settlementWindow.settlementWindowId', 'settlementSettlementWindow.settlementWindowId')
           .join('settlementWindowStateChange AS swsc', 'swsc.settlementWindowStateChangeId', 'settlementWindow.currentStateChangeId')

--- a/src/models/settlement/participantCurrency.js
+++ b/src/models/settlement/participantCurrency.js
@@ -29,7 +29,7 @@
 const Db = require('../../lib/db')
 
 const checkParticipantAccountExists = async ({ participantId, accountId }, enums = {}) => {
-  return Db.participantCurrency.query(builder => {
+  return Db.from('participantCurrency').query(builder => {
     return builder
       .select('participantCurrencyId')
       .where({ participantId })

--- a/src/models/settlement/settlement.js
+++ b/src/models/settlement/settlement.js
@@ -29,14 +29,14 @@
 const Db = require('../../lib/db')
 
 const create = async (settlement) => {
-  return Db.settlement.insert({
+  return Db.from('settlement').insert({
     reason: settlement.reason,
     createdDate: settlement.createdDate
   })
 }
 
 const getById = async (id) => {
-  return Db.settlement.findOne({ settlementId: id })
+  return Db.from('settlement').findOne({ settlementId: id })
 }
 
 module.exports = {

--- a/src/models/settlement/settlementModel.js
+++ b/src/models/settlement/settlementModel.js
@@ -27,7 +27,7 @@
 const Db = require('../../lib/db')
 
 const getByName = async (name) => {
-  return Db.settlementModel.findOne({ name, isActive: 1 })
+  return Db.from('settlementModel').findOne({ name, isActive: 1 })
 }
 
 module.exports = {

--- a/src/models/settlement/settlementParticipantCurrency.js
+++ b/src/models/settlement/settlementParticipantCurrency.js
@@ -29,7 +29,7 @@
 const Db = require('../../lib/db')
 
 const getAccountInSettlement = async ({ settlementId, accountId }) => {
-  const result = await Db.settlementParticipantCurrency.query(builder => {
+  const result = await Db.from('settlementParticipantCurrency').query(builder => {
     return builder
       .select('settlementParticipantCurrencyId')
       .where({ settlementId })
@@ -40,7 +40,7 @@ const getAccountInSettlement = async ({ settlementId, accountId }) => {
 }
 
 const getBySettlementAndAccount = async (settlementId, accountId) => {
-  const result = await Db.settlementParticipantCurrency.query(builder => {
+  const result = await Db.from('settlementParticipantCurrency').query(builder => {
     return builder
       .innerJoin('settlementParticipantCurrencyStateChange AS spcsc', 'spcsc.settlementParticipantCurrencyStateChangeId', 'settlementParticipantCurrency.currentStateChangeId')
       .select('settlementParticipantCurrency.*', 'spcsc.settlementStateId', 'spcsc.reason', 'spcsc.externalReference')

--- a/src/models/settlement/settlementTransferParticipant.js
+++ b/src/models/settlement/settlementTransferParticipant.js
@@ -32,7 +32,7 @@ const Db = require('../../lib/db')
 
 module.exports = {
   getBySettlementId: async function ({ settlementId }) {
-    return Db.settlementTransferParticipant.query(builder => {
+    return Db.from('settlementTransferParticipant').query(builder => {
       return builder
         .select()
         .distinct('settlementWindowId', 'participantCurrencyId')

--- a/src/models/settlementWindow/facade.js
+++ b/src/models/settlementWindow/facade.js
@@ -32,7 +32,7 @@ const Enum = require('@mojaloop/central-services-shared').Enum
 
 const Facade = {
   getById: async function ({ settlementWindowId }) {
-    return Db.settlementWindow.query(builder => {
+    return Db.from('settlementWindow').query(builder => {
       return builder
         .leftJoin('settlementWindowStateChange AS swsc', 'swsc.settlementWindowStateChangeId', 'settlementWindow.currentStateChangeId')
         .select(
@@ -48,7 +48,7 @@ const Facade = {
   },
 
   getTransfersCount: async function ({ settlementWindowId }) {
-    return Db.transferFulfilment.query(builder => {
+    return Db.from('transferFulfilment').query(builder => {
       return builder
         .count('* as cnt')
         .first()
@@ -58,7 +58,7 @@ const Facade = {
 
   getByListOfIds: async function (listOfIds, settlementModel, winStateEnum) {
     const knex = await Db.getKnex()
-    return Db.settlementWindow.query(builder => {
+    return Db.from('settlementWindow').query(builder => {
       const b = builder
         .join('settlementWindowStateChange AS swsc', 'swsc.settlementWindowStateChangeId', 'settlementWindow.currentStateChangeId')
         .join('settlementWindowContent AS swc', 'swc.settlementWindowId', 'settlementWindow.settlementWindowId')
@@ -78,7 +78,7 @@ const Facade = {
 
   getByParams: async function ({ query }) {
     const { participantId, state, fromDateTime, toDateTime, currency } = query
-    return Db.settlementWindow.query(builder => {
+    return Db.from('settlementWindow').query(builder => {
       if (!participantId) {
         const b = builder
           .leftJoin('settlementWindowStateChange AS swsc', 'swsc.settlementWindowStateChangeId', 'settlementWindow.currentStateChangeId')
@@ -279,7 +279,7 @@ const Facade = {
   },
 
   getBySettlementId: async function ({ settlementId }) {
-    return Db.settlementSettlementWindow.query(builder => {
+    return Db.from('settlementSettlementWindow').query(builder => {
       return builder
         .join('settlementWindow AS sw', 'sw.settlementWindowId', 'settlementSettlementWindow.settlementWindowId')
         .join('settlementWindowStateChange AS swsc', 'swsc.settlementWindowStateChangeId', 'sw.currentStateChangeId')

--- a/src/models/settlementWindow/settlementWindowStateChange.js
+++ b/src/models/settlementWindow/settlementWindowStateChange.js
@@ -29,7 +29,7 @@
 const Db = require('../../lib/db')
 
 const create = async ({ settlementWindowId, state, reason }, enums = {}) => {
-  return Db.settlementWindowStateChange.insert({
+  return Db.from('settlementWindowStateChange').insert({
     settlementWindowId,
     settlementWindowStateId: enums[state.toUpperCase()],
     reason

--- a/src/models/settlementWindowContent/facade.js
+++ b/src/models/settlementWindowContent/facade.js
@@ -29,7 +29,7 @@ const Db = require('../../lib/db')
 const Facade = {
   getApplicableByWindowIdList: async function (idList, settlementModel, winStateEnum) {
     const knex = await Db.getKnex()
-    return Db.settlementWindow.query(builder => {
+    return Db.from('settlementWindow').query(builder => {
       const b = builder
         .join('settlementWindowStateChange AS swsc', 'swsc.settlementWindowStateChangeId', 'settlementWindow.currentStateChangeId')
         .join('settlementWindowContent AS swc', 'swc.settlementWindowId', 'settlementWindow.settlementWindowId')

--- a/src/models/settlementWindowContent/settlementWindowContentStateChange.js
+++ b/src/models/settlementWindowContent/settlementWindowContentStateChange.js
@@ -27,7 +27,7 @@
 const Db = require('../../lib/db')
 
 const create = async ({ settlementWindowContentId, state, reason }, enums = {}) => {
-  return Db.settlementWindowContentStateChange.insert({
+  return Db.from('settlementWindowContentStateChange').insert({
     settlementWindowContentId,
     settlementWindowStateId: enums[state.toUpperCase()],
     reason

--- a/src/shared/setup.js
+++ b/src/shared/setup.js
@@ -43,7 +43,10 @@ const getEnums = (id) => {
 }
 
 async function connectDatabase () {
-  return Db.connect(Config.DATABASE)
+  Logger.isDebugEnabled && Logger.debug(`Conneting to DB ${JSON.stringify(Config.DATABASE)}`)
+  await Db.connect(Config.DATABASE)
+  const dbLoadedTables = Db._tables ? Db._tables.length : -1
+  Logger.isDebugEnabled && Logger.debug(`DB.connect loaded '${dbLoadedTables}' tables!`)
 }
 
 const createServer = async function (port, modules) {

--- a/src/shared/setup.js
+++ b/src/shared/setup.js
@@ -43,10 +43,10 @@ const getEnums = (id) => {
 }
 
 async function connectDatabase () {
-  Logger.isDebugEnabled && Logger.debug(`Conneting to DB ${JSON.stringify(Config.DATABASE)}`)
+  Logger.debug(`Conneting to DB ${JSON.stringify(Config.DATABASE)}`)
   await Db.connect(Config.DATABASE)
   const dbLoadedTables = Db._tables ? Db._tables.length : -1
-  Logger.isDebugEnabled && Logger.debug(`DB.connect loaded '${dbLoadedTables}' tables!`)
+  Logger.debug(`DB.connect loaded '${dbLoadedTables}' tables!`)
 }
 
 const createServer = async function (port, modules) {

--- a/test/unit/domain/transactions/index.test.js
+++ b/test/unit/domain/transactions/index.test.js
@@ -40,6 +40,11 @@ Test('Transactions Service', async (transactionsTest) => {
     Db.ilpPacket = {
       find: sandbox.stub()
     }
+
+    Db.from = (table) => {
+      return Db[table]
+    }
+
     t.end()
   })
 

--- a/test/unit/models/ilpPackets/ilpPacket.test.js
+++ b/test/unit/models/ilpPackets/ilpPacket.test.js
@@ -31,10 +31,27 @@ const Logger = require('@mojaloop/central-services-logger')
 const IlpPacketsModel = require('../../../../src/models/ilpPackets/ilpPacket')
 
 Test('IlpPackets', async (IlpPacketsTest) => {
-  const sandbox = Sinon.createSandbox()
-  Db.ilpPacket = {
-    find: sandbox.stub()
-  }
+  let sandbox
+
+  IlpPacketsTest.beforeEach(t => {
+    sandbox = Sinon.createSandbox()
+
+    Db.ilpPacket = {
+      find: sandbox.stub()
+    }
+
+    Db.from = (table) => {
+      return Db[table]
+    }
+
+    t.end()
+  })
+
+  IlpPacketsTest.afterEach(t => {
+    sandbox.restore()
+
+    t.end()
+  })
 
   await IlpPacketsTest.test('get IlpPackets with transferId', async (assert) => {
     try {

--- a/test/unit/models/lib/enums.test.js
+++ b/test/unit/models/lib/enums.test.js
@@ -35,6 +35,11 @@ Test('Enums', async (enumsTest) => {
 
   enumsTest.beforeEach(test => {
     sandbox = Sinon.createSandbox()
+
+    Db.from = (table) => {
+      return Db[table]
+    }
+
     test.end()
   })
 

--- a/test/unit/models/misc/migrationLock.test.js
+++ b/test/unit/models/misc/migrationLock.test.js
@@ -34,6 +34,11 @@ Test('MigrationLock model', async (migrationLockTest) => {
 
   migrationLockTest.beforeEach(t => {
     sandbox = Sinon.createSandbox()
+
+    Db.from = (table) => {
+      return Db[table]
+    }
+
     Db.migration_lock = {
       query: sandbox.stub()
     }

--- a/test/unit/models/settlement/facade.test.js
+++ b/test/unit/models/settlement/facade.test.js
@@ -43,6 +43,9 @@ Test('Settlement facade', async (settlementFacadeTest) => {
   settlementFacadeTest.beforeEach(test => {
     sandbox = Sinon.createSandbox()
     clock = Sinon.useFakeTimers(now.getTime())
+    Db.from = (table) => {
+      return Db[table]
+    }
     test.end()
   })
 

--- a/test/unit/models/settlement/participantCurrency.test.js
+++ b/test/unit/models/settlement/participantCurrency.test.js
@@ -35,6 +35,9 @@ Test('ParticipantCurrencyModel', async (participantCurrencyModelTest) => {
 
   participantCurrencyModelTest.beforeEach(test => {
     sandbox = Sinon.createSandbox()
+    Db.from = (table) => {
+      return Db[table]
+    }
     test.end()
   })
 

--- a/test/unit/models/settlement/settlement.test.js
+++ b/test/unit/models/settlement/settlement.test.js
@@ -35,6 +35,9 @@ Test('SettlementModel', async (settlementModelTest) => {
 
   settlementModelTest.beforeEach(test => {
     sandbox = Sinon.createSandbox()
+    Db.from = (table) => {
+      return Db[table]
+    }
     test.end()
   })
 

--- a/test/unit/models/settlement/settlementModel.test.js
+++ b/test/unit/models/settlement/settlementModel.test.js
@@ -36,6 +36,9 @@ Test('SettlementModelModel', async (settlementModelModelTest) => {
 
   settlementModelModelTest.beforeEach(t => {
     sandbox = Sinon.createSandbox()
+    Db.from = (table) => {
+      return Db[table]
+    }
     t.end()
   })
 

--- a/test/unit/models/settlement/settlementParticipantCurrency.test.js
+++ b/test/unit/models/settlement/settlementParticipantCurrency.test.js
@@ -36,6 +36,9 @@ Test('SettlementParticipantCurrencyModel', async (settlementParticipantCurrencyM
 
   settlementParticipantCurrencyModelTest.beforeEach(test => {
     sandbox = Sinon.createSandbox()
+    Db.from = (table) => {
+      return Db[table]
+    }
     test.end()
   })
 

--- a/test/unit/models/settlement/settlementStateChange.test.js
+++ b/test/unit/models/settlement/settlementStateChange.test.js
@@ -35,6 +35,9 @@ Test('SettlementStateChangeModel', async (SettlementStateChangeModelTest) => {
 
   SettlementStateChangeModelTest.beforeEach(test => {
     sandbox = Sinon.createSandbox()
+    Db.from = (table) => {
+      return Db[table]
+    }
     test.end()
   })
 

--- a/test/unit/models/settlement/settlementTransferParticipant.test.js
+++ b/test/unit/models/settlement/settlementTransferParticipant.test.js
@@ -35,6 +35,9 @@ Test('SettlementTransferParticipantModel', async (settlementTransferParticipantM
 
   settlementTransferParticipantModelTest.beforeEach(test => {
     sandbox = Sinon.createSandbox()
+    Db.from = (table) => {
+      return Db[table]
+    }
     test.end()
   })
 

--- a/test/unit/models/settlementWindow/facade.test.js
+++ b/test/unit/models/settlementWindow/facade.test.js
@@ -53,6 +53,9 @@ Test('Settlement Window facade', async (settlementWindowFacadeTest) => {
   settlementWindowFacadeTest.beforeEach(test => {
     sandbox = Sinon.createSandbox()
     clock = Sinon.useFakeTimers(now.getTime())
+    Db.from = (table) => {
+      return Db[table]
+    }
     Db.settlementWindow = {
       query: sandbox.stub()
     }

--- a/test/unit/models/settlementWindow/settlementWindowStateChange.test.js
+++ b/test/unit/models/settlementWindow/settlementWindowStateChange.test.js
@@ -35,6 +35,9 @@ Test('SettlementModel', async (settlementWindowStateChangeModelTest) => {
 
   settlementWindowStateChangeModelTest.beforeEach(test => {
     sandbox = Sinon.createSandbox()
+    Db.from = (table) => {
+      return Db[table]
+    }
     test.end()
   })
 

--- a/test/unit/models/settlementWindowContent/facade.test.js
+++ b/test/unit/models/settlementWindowContent/facade.test.js
@@ -35,6 +35,9 @@ Test('SettlementWindowContentFacade', async (settlementWindowContentModelTest) =
 
   settlementWindowContentModelTest.beforeEach(test => {
     sandbox = Sinon.createSandbox()
+    Db.from = (table) => {
+      return Db[table]
+    }
     test.end()
   })
 

--- a/test/unit/models/settlementWindowContent/settlementWindowContentStateChange.test.js
+++ b/test/unit/models/settlementWindowContent/settlementWindowContentStateChange.test.js
@@ -35,6 +35,9 @@ Test('SettlementModel', async (settlementWindowContentStateChangeModelTest) => {
 
   settlementWindowContentStateChangeModelTest.beforeEach(test => {
     sandbox = Sinon.createSandbox()
+    Db.from = (table) => {
+      return Db[table]
+    }
     test.end()
   })
 

--- a/test/unit/models/transferSettlement/facade.test.js
+++ b/test/unit/models/transferSettlement/facade.test.js
@@ -74,6 +74,9 @@ Test('TransferSettlement facade', async (transferSettlementTest) => {
 
   transferSettlementTest.beforeEach(t => {
     sandbox = Sinon.createSandbox()
+    Db.from = (table) => {
+      return Db[table]
+    }
     trxStub = {
       get commit () {
 


### PR DESCRIPTION
Ref: https://github.com/mojaloop/project/issues/1888. Fix issue by changing all `Db.<table>.*` syntax function operations to `Db.from('<table>').*`. The issue was caused by the central-services-database Database class on Db.connect() loading all tables via an SQL request, and creating a Class property (`Db.<table>`) to reference the Table object. The issue here being that the query to fetch all the tables from the database does not return all tables (to be investigated in future).  `Db.from('<table>').*` ensures that the table object is created properly.

Future stories:
- Enhancement: Modify the `Db.from('<table>')` function to cache created Table objects
- Investigation: Understand why on startup the DB.connect() loading operation does not load all tables consistently.