### PR TITLE
feat():sp-settlement-api-participant-identifier-is-not-compatible-with-fspiop-identifiers

### DIFF
--- a/src/interface/swagger.json
+++ b/src/interface/swagger.json
@@ -1194,7 +1194,14 @@
             "type": "object",
             "properties": {
                 "id": {
-                    "type": "integer"
+                    "type": "integer",
+                    "description": "FSP identifier",
+                    "example": 1
+                },
+                "name": {
+                    "$ref": "#/definitions/FspId",
+                    "description": "FSPIOP identifier name",
+                    "example": "payerFsp"
                 },
                 "accounts": {
                     "type": "array",
@@ -1203,6 +1210,13 @@
                     }
                 }
             }
+        },
+        "FspId": {
+            "title": "FspId",
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 32,
+            "description": "FSP identifier"
         },
         "Settlements": {
             "type": "array",


### PR DESCRIPTION
- Solution Proposal for [mojaloop-specification/change-request/91](https://github.com/mojaloop/mojaloop-specification/issues/91)
- Included definition for fspId from the FSPIOP Specification
- Updated swagger to include participant name (i.e. fspId) in the Participant definition